### PR TITLE
Add wayland support to wisdom for linux

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,36 @@
+---
+BasedOnStyle: WebKit
+Standard: Cpp11
+SortIncludes: false
+
+ColumnLimit: 0
+ContinuationIndentWidth: 8
+
+FixNamespaceComments: true
+NamespaceIndentation: None
+AlignAfterOpenBracket: true
+
+PointerBindsToType: false
+SpaceAfterTemplateKeyword: false
+
+AllowShortFunctionsOnASingleLine: Inline
+ConstructorInitializerAllOnOneLineOrOnePerLine: true
+AlwaysBreakTemplateDeclarations: true
+BreakBeforeBinaryOperators: None
+
+SpaceBeforeCpp11BracedList: false
+BreakBeforeBraces: Custom
+BraceWrapping:
+    AfterClass: true
+    AfterControlStatement: false
+    AfterEnum: false
+    AfterFunction: true
+    AfterNamespace: false
+    AfterObjCDeclaration: false
+    AfterStruct: false
+    AfterUnion: false
+    BeforeCatch: false
+    BeforeElse: false
+    IndentBraces: false
+
+CommentPragmas:  '/\*(.+\n.+)+\*/'

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,6 +41,7 @@ option(WISDOM_FORCE_VULKAN "Forces the default device to be vulkan, instead of p
 option(WISDOM_BUILD_EXAMPLES "Build the example project." ${WTOP})
 option(WISDOM_BUILD_TESTS "Build the tests." ${WTOP})
 option(WISDOM_BUILD_DOCS "Build the documentation." ${WTOP})
+option(WISDOM_USE_SYSTEM_DXC "Use dxc from PATH" OFF)
 
 
 if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU" AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS "13"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -63,6 +63,12 @@ endif()
 
 set(WISDOM_VERSION "v${PROJECT_VERSION_MAJOR}_${PROJECT_VERSION_MINOR}")
 
+# TODO: find a better way to do this (only required by vulkan-hpp) and make
+# wayland support a build option
+if (CMAKE_SYSTEM_NAME STREQUAL "Linux")
+    add_compile_definitions(VK_USE_PLATFORM_WAYLAND_KHR)
+endif()
+
 
 # Additional CMake functions.
 include(Misc.cmake)

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -3,12 +3,16 @@ set(FETCHCONTENT_UPDATES_DISCONNECTED ON)
 include(FetchContent)
 
 # math library
-FetchContent_Declare(
-	glm
-	GIT_REPOSITORY https://github.com/g-truc/glm.git
-	GIT_TAG        master
-)
-FetchContent_MakeAvailable(glm)
+find_package(glm QUIET)
+
+if (NOT glm_FOUND)
+    FetchContent_Declare(
+        glm
+        GIT_REPOSITORY https://github.com/g-truc/glm.git
+        GIT_TAG        master
+    )
+    FetchContent_MakeAvailable(glm)
+endif()
 
 
 

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -14,14 +14,31 @@ if (NOT glm_FOUND)
     FetchContent_MakeAvailable(glm)
 endif()
 
+# windows store example does not need kdutils
+if (NOT WINDOWS_STORE)
+    set(BUILD_SHARED_LIBS OFF)
+    set(KDUTILS_BUILD_TESTS OFF)
 
+    find_package(KDUtils CONFIG)
+    if(NOT KDUtils_FOUND)
+        FetchContent_Declare(
+            KDUtils
+            GIT_REPOSITORY https://github.com/KDAB/KDUtils.git
+            GIT_TAG        master
+        )
+        FetchContent_MakeAvailable(KDUtils)
+    endif()
+
+    find_package(KDFoundation CONFIG)
+    find_package(KDGui CONFIG)
+endif()
 
 add_subdirectory(shaders)
 
 find_package(Vulkan)
 
 if(WISDOM_BUILD_TYPE STREQUAL "modules")
-			add_subdirectory(hello-triangle-modules)
+	add_subdirectory(hello-triangle-modules)
 elseif(WINDOWS_STORE)
 	add_subdirectory(hello-triangle-winrt)
 else()
@@ -30,6 +47,7 @@ else()
 	endif()
 	if(Vulkan_FOUND)
 		add_subdirectory(hello-triangle-kdgui)
+		add_subdirectory(uniform-buffers-kdgui)
 	endif()
 endif()
 

--- a/examples/hello-triangle-kdgui/CMakeLists.txt
+++ b/examples/hello-triangle-kdgui/CMakeLists.txt
@@ -31,7 +31,7 @@ target_link_libraries(
 )
 set_target_properties(${PROJECT_NAME}
     PROPERTIES
-        CXX_STANDARD 23
+        CXX_STANDARD 20
 )
 target_compile_definitions(${PROJECT_NAME} 
 	PUBLIC 

--- a/examples/hello-triangle-kdgui/CMakeLists.txt
+++ b/examples/hello-triangle-kdgui/CMakeLists.txt
@@ -1,15 +1,20 @@
 project(hello-triangle-kdgui)
 
-FetchContent_Declare(
-	kdgui
-	GIT_REPOSITORY https://github.com/KDAB/KDUtils.git
-	GIT_TAG        master
-)
 set(BUILD_SHARED_LIBS OFF)
 set(KDUTILS_BUILD_TESTS OFF)
-FetchContent_MakeAvailable(kdgui)
 
+find_package(KDUtils CONFIG)
+if(NOT KDUtils_FOUND)
+    FetchContent_Declare(
+        KDUtils
+        GIT_REPOSITORY https://github.com/KDAB/KDUtils.git
+        GIT_TAG        master
+    )
+    FetchContent_MakeAvailable(KDUtils)
+endif()
 
+find_package(KDFoundation CONFIG)
+find_package(KDGui CONFIG)
 
 add_executable(${PROJECT_NAME}
 	entry_main.cpp "window.h"

--- a/examples/hello-triangle-kdgui/window.cpp
+++ b/examples/hello-triangle-kdgui/window.cpp
@@ -18,6 +18,8 @@
 #endif
 #if defined(KD_PLATFORM_LINUX)
 #include <KDGui/platform/linux/xcb/linux_xcb_platform_window.h>
+#include <KDGui/platform/linux/wayland/linux_wayland_platform_window.h>
+#include <KDGui/platform/linux/wayland/linux_wayland_platform_integration.h>
 #endif
 #if defined(KD_PLATFORM_MACOS)
 extern CAMetalLayer* createMetalLayer(KDGui::Window* window);
@@ -61,11 +63,21 @@ wis::SurfaceParameters Window::GetSurfaceOptions()const noexcept
 		win32Window->handle()
 	};
 #elif defined(KD_PLATFORM_LINUX)
-	auto xcbWindow = dynamic_cast<KDGui::LinuxXcbPlatformWindow*>(p->platformWindow());
-	return wis::SurfaceParameters{
-		xcbWindow->connection(),
-		xcbWindow->handle()
-	};
+    if (KDGui::LinuxWaylandPlatformIntegration::checkAvailable()) {
+        auto *platformIntegration = KDGui::GuiApplication::instance()->guiPlatformIntegration();
+        auto *waylandPlatformIntegration = dynamic_cast<KDGui::LinuxWaylandPlatformIntegration *>(platformIntegration);
+        auto waylandWindow = dynamic_cast<KDGui::LinuxWaylandPlatformWindow *>(p->platformWindow());
+        return wis::SurfaceParameters{
+            waylandPlatformIntegration->display(),
+            waylandWindow->surface(),
+        };
+    } else {
+        auto *xcbWindow = dynamic_cast<KDGui::LinuxXcbPlatformWindow *>(p->platformWindow());
+        return wis::SurfaceParameters{
+            xcbWindow->connection(),
+            xcbWindow->handle(),
+        };
+    }
 #elif defined(KD_PLATFORM_MACOS)
 	return wis::SurfaceParameters{
 		.layer = createMetalLayer(this)

--- a/examples/hello-triangle-modules/CMakeLists.txt
+++ b/examples/hello-triangle-modules/CMakeLists.txt
@@ -19,7 +19,7 @@ target_link_libraries(
 )
 set_target_properties(${PROJECT_NAME}
     PROPERTIES
-        CXX_STANDARD 23
+        CXX_STANDARD 20
 )
 target_compile_definitions(${PROJECT_NAME} 
 	PUBLIC 

--- a/examples/hello-triangle-modules/CMakeLists.txt
+++ b/examples/hello-triangle-modules/CMakeLists.txt
@@ -1,15 +1,20 @@
 project(hello-triangle-modules)
 
-FetchContent_Declare(
-	kdgui
-	GIT_REPOSITORY https://github.com/KDAB/KDUtils.git
-	GIT_TAG        master
-)
 set(BUILD_SHARED_LIBS OFF)
 set(KDUTILS_BUILD_TESTS OFF)
-FetchContent_MakeAvailable(kdgui)
 
+find_package(KDUtils CONFIG)
+if(NOT KDUtils_FOUND)
+    FetchContent_Declare(
+        KDUtils
+        GIT_REPOSITORY https://github.com/KDAB/KDUtils.git
+        GIT_TAG        master
+    )
+    FetchContent_MakeAvailable(KDUtils)
+endif()
 
+find_package(KDFoundation CONFIG)
+find_package(KDGui CONFIG)
 
 add_executable(${PROJECT_NAME}
 	entry_main.cpp 

--- a/examples/hello-triangle-modules/window.ixx
+++ b/examples/hello-triangle-modules/window.ixx
@@ -8,6 +8,8 @@ module;
 #endif
 #if defined(KD_PLATFORM_LINUX)
 #include <KDGui/platform/linux/xcb/linux_xcb_platform_window.h>
+#include <KDGui/platform/linux/wayland/linux_wayland_platform_window.h>
+#include <KDGui/platform/linux/wayland/linux_wayland_platform_integration.h>
 #endif
 #if defined(KD_PLATFORM_MACOS)
 extern CAMetalLayer* createMetalLayer(KDGui::Window* window);
@@ -86,11 +88,21 @@ wis::SurfaceParameters Window::GetSurfaceOptions()const noexcept
 		win32Window->handle()
 	};
 #elif defined(KD_PLATFORM_LINUX)
-	auto xcbWindow = dynamic_cast<KDGui::LinuxXcbPlatformWindow*>(p->platformWindow());
-	return wis::SurfaceParameters{
-		xcbWindow->connection(),
-		xcbWindow->handle()
-	};
+    if (KDGui::LinuxWaylandPlatformIntegration::checkAvailable()) {
+        auto *platformIntegration = KDGui::GuiApplication::instance()->guiPlatformIntegration();
+        auto *waylandPlatformIntegration = dynamic_cast<KDGui::LinuxWaylandPlatformIntegration *>(platformIntegration);
+        auto waylandWindow = dynamic_cast<KDGui::LinuxWaylandPlatformWindow *>(p->platformWindow());
+        return wis::SurfaceParameters{
+            waylandPlatformIntegration->display(),
+            waylandWindow->surface(),
+        };
+    } else {
+        auto *xcbWindow = dynamic_cast<KDGui::LinuxXcbPlatformWindow *>(p->platformWindow());
+        return wis::SurfaceParameters{
+            xcbWindow->connection(),
+            xcbWindow->handle(),
+        };
+    }
 #elif defined(KD_PLATFORM_MACOS)
 	return wis::SurfaceParameters{
 		.layer = createMetalLayer(this)

--- a/examples/hello-triangle-win32/CMakeLists.txt
+++ b/examples/hello-triangle-win32/CMakeLists.txt
@@ -29,7 +29,7 @@ target_link_libraries(
 
 set_target_properties(${PROJECT_NAME}
     PROPERTIES
-        CXX_STANDARD 23
+        CXX_STANDARD 20
 )
 
 target_include_directories(${PROJECT_NAME} PUBLIC

--- a/examples/hello-triangle-win32/include/example/window.h
+++ b/examples/hello-triangle-win32/include/example/window.h
@@ -4,6 +4,7 @@
 #include "Menu.h"
 #include <optional>
 #include <array>
+#include <type_traits>
 
 namespace ver
 {
@@ -18,7 +19,7 @@ enum class Event : uint8_t
 	Play,
 	Count
 };
-constexpr inline auto operator+(Event e) { return std::to_underlying(e); }
+constexpr inline auto operator+(Event e) { return static_cast<std::underlying_type<Event>::type>(e); }
 
 struct EventSet
 {

--- a/examples/hello-triangle-winrt/CMakeLists.txt
+++ b/examples/hello-triangle-winrt/CMakeLists.txt
@@ -43,7 +43,7 @@ target_compile_definitions(${PROJECT_NAME}
         WINRT_LEAN_AND_MEAN
 )
 set_target_properties(${PROJECT_NAME} PROPERTIES 
-    CXX_STANDARD 23    
+    CXX_STANDARD 20    
     CXX_STANDARD_REQUIRED ON
     CXX_EXTENSIONS OFF
 )

--- a/examples/uniform-buffers-kdgui/CMakeLists.txt
+++ b/examples/uniform-buffers-kdgui/CMakeLists.txt
@@ -15,7 +15,7 @@ target_link_libraries(
 )
 set_target_properties(${PROJECT_NAME}
     PROPERTIES
-        CXX_STANDARD 23
+        CXX_STANDARD 20
 )
 target_compile_definitions(${PROJECT_NAME} 
 	PUBLIC 

--- a/examples/uniform-buffers-kdgui/CMakeLists.txt
+++ b/examples/uniform-buffers-kdgui/CMakeLists.txt
@@ -1,12 +1,8 @@
-project(hello-triangle-modules)
+project(uniform-buffers-kdgui)
 
 add_executable(${PROJECT_NAME}
-	entry_main.cpp 
- )
-
-target_sources(${PROJECT_NAME}
-PUBLIC FILE_SET CXX_MODULES 
-	FILES "window.ixx" "app.ixx")
+	entry_main.cpp "window.h"
+ "window.cpp" "app.h" "app.cpp")
 
 if(WIN32)
 	include(${CMAKE_CURRENT_SOURCE_DIR}/../../cmake/Functions.cmake)

--- a/examples/uniform-buffers-kdgui/app.cpp
+++ b/examples/uniform-buffers-kdgui/app.cpp
@@ -1,0 +1,199 @@
+#include "app.h"
+#include <iostream>
+#include <filesystem>
+#include <fstream>
+#include <glm/vec4.hpp>
+#include <glm/vec3.hpp>
+
+struct LogProvider : public wis::LogLayer {
+    virtual void Log(wis::Severity sev, std::string message, wis::source_location sl = wis::source_location::current()) override
+    {
+        std::cout << wis::format("[{}]: {}\n", wis::severity_strings[+sev], message);
+    };
+};
+
+constexpr wis::ApplicationInfo app_info{
+    .application_name = "example",
+    .engine_name = "none",
+};
+
+// not WinRT Compatible
+template<class ShaderTy>
+auto LoadShader(std::filesystem::path p)
+{
+    if constexpr (ShaderTy::language == wis::ShaderLang::dxil)
+        p += ".cso";
+    else if constexpr (ShaderTy::language == wis::ShaderLang::spirv)
+        p += ".spv";
+
+    std::ifstream t{ p, std::ios::binary };
+    t.seekg(0, std::ios::end);
+    size_t size = t.tellg();
+    wis::shared_blob ret{ size };
+    t.seekg(0);
+    t.read(ret.data<char>(), size);
+    return ret;
+}
+
+template<class T>
+std::span<std::byte> RawView(T &data)
+{
+    return { (std::byte *)&data, sizeof(T) };
+}
+
+Test::App::App(uint32_t width, uint32_t height)
+    : wnd(app.createWindow(width, height))
+{
+    wis::LibLogger::SetLogLayer(std::make_shared<LogProvider>());
+
+    factory.emplace(app_info);
+
+    for (auto &&a : factory->EnumerateAdapters(wis::AdapterPreference::Performance)) {
+        auto desc = a.GetDesc();
+
+        if (desc.IsSoftware())
+            wis::lib_warn("Loading WARP adapter");
+
+        std::cout << desc.to_string();
+
+        if (device.Initialize(a)) {
+            allocator = wis::ResourceAllocator{ device, a };
+            break;
+        }
+    }
+
+    queue = device.CreateCommandQueue();
+
+    swap = device.CreateSwapchain(queue, wis::SwapchainOptions{ uint32_t(width), uint32_t(height), wis::SwapchainOptions::default_frames, wis::SwapchainOptions::default_format, true }, wnd.GetSurfaceOptions());
+
+    fence = device.CreateFence();
+    context = device.CreateCommandList(wis::QueueType::direct);
+
+    std::array cas2{
+        wis::ColorAttachment{
+                .format = wis::SwapchainOptions::default_format,
+                .load = wis::PassLoadOperation::clear },
+        wis::ColorAttachment{
+                .format = wis::SwapchainOptions::default_format,
+                .load = wis::PassLoadOperation::clear }
+    };
+
+    render_pass = device.CreateRenderPass({ width, height }, { cas2.data(), swap.StereoSupported() + 1u });
+
+    vs = device.CreateShader(LoadShader<wis::Shader>(SHADER_DIR "/example.vs"), wis::ShaderType::vertex);
+    ps = device.CreateShader(LoadShader<wis::Shader>(SHADER_DIR "/example.ps"), wis::ShaderType::pixel);
+
+    root = device.CreateRootSignature(); // empty
+
+    static constexpr std::array<wis::InputLayoutDesc, 2> ia{
+        wis::InputLayoutDesc{ 0, "POSITION", 0, wis::DataFormat::r32g32b32_float, 0, 0, wis::InputClassification::vertex, 0 },
+        wis::InputLayoutDesc{ 1, "COLOR", 0, wis::DataFormat::r32g32b32a32_float, 0, 12, wis::InputClassification::vertex, 0 }
+    };
+
+    wis::GraphicsPipelineDesc desc{ root };
+    desc.SetVS(vs);
+    desc.SetPS(ps);
+    desc.SetRenderPass(render_pass);
+    pipeline = device.CreateGraphicsPipeline(std::move(desc), ia);
+
+    struct Vertex {
+        glm::vec3 pos;
+        glm::vec4 col;
+    };
+    auto aspect_ratio = float(width) / float(height);
+    Vertex triangleVertices[] = {
+        { { 0.0f, 0.25f * aspect_ratio, 0.0f }, { 1.0f, 0.0f, 0.0f, 1.0f } },
+        { { 0.25f, -0.25f * aspect_ratio, 0.0f }, { 0.0f, 1.0f, 0.0f, 1.0f } },
+        { { -0.25f, -0.25f * aspect_ratio, 0.0f }, { 0.0f, 0.0f, 1.0f, 1.0f } }
+    };
+
+    vertex_buffer = allocator.CreatePersistentBuffer(sizeof(triangleVertices), wis::BufferFlags::VertexBuffer);
+
+    auto upl_vbuf = allocator.CreateUploadBuffer(sizeof(triangleVertices));
+    upl_vbuf.UpdateSubresource(RawView(triangleVertices));
+
+    context.Reset();
+    context.CopyBuffer(upl_vbuf, vertex_buffer, sizeof(triangleVertices));
+    context.BufferBarrier({ .access_before = wis::ResourceAccess::CopyDest,
+                            .access_after = wis::ResourceAccess::VertexBuffer },
+                          vertex_buffer);
+    context.Close();
+
+    queue.ExecuteCommandList(context);
+    WaitForGPU();
+
+    vb = vertex_buffer.GetVertexBufferView(sizeof(Vertex));
+    context.SetPipeline(pipeline);
+
+    auto x = swap.GetRenderTargets();
+    for (size_t i = 0; i < x.size(); i++) {
+        rtvs[i] = device.CreateRenderTargetView(x[i]);
+        if (swap.StereoSupported())
+            rtvs2[i] = device.CreateRenderTargetView(x[i], { .base_layer = 1 });
+    }
+}
+Test::App::~App()
+{
+    WaitForGPU();
+}
+int Test::App::Start()
+{
+    while (true) {
+        app.ProcessEvents();
+        if (!wnd.visible())
+            return 0;
+        // Process Events
+
+        Frame();
+    }
+}
+void Test::App::Frame()
+{
+    context.Reset();
+    auto back = swap.GetBackBuffer();
+
+    context.TextureBarrier({ .state_before = wis::TextureState::Present,
+                             .state_after = wis::TextureState::RenderTarget,
+                             .access_before = wis::ResourceAccess::Common,
+                             .access_after = wis::ResourceAccess::RenderTarget },
+                           back);
+
+    constexpr wis::ColorClear color{ 0.0f, 0.2f, 0.4f, 1.0f };
+    constexpr wis::ColorClear color2{ 1.0f, 0.2f, 0.4f, 1.0f };
+    std::array rtvsx{
+        std::pair{ rtvs[swap.GetNextIndex()], color },
+        std::pair{ rtvs2[swap.GetNextIndex()], color2 }
+    };
+
+    context.SetGraphicsRootSignature(root);
+    context.RSSetViewport({ float(wnd.width()), float(wnd.height()) });
+    context.RSSetScissorRect({ long(wnd.width()), long(wnd.height()) });
+    context.IASetPrimitiveTopology(wis::PrimitiveTopology::trianglelist);
+    context.IASetVertexBuffers({ &vb, 1 });
+
+    context.BeginRenderPass(render_pass, { rtvsx.data(), swap.StereoSupported() + 1u });
+    context.DrawInstanced(3);
+    context.EndRenderPass();
+
+    context.TextureBarrier({
+                                   .state_before = wis::TextureState::RenderTarget,
+                                   .state_after = wis::TextureState::Present,
+                                   .access_before = wis::ResourceAccess::RenderTarget,
+                                   .access_after = wis::ResourceAccess::Common,
+                           },
+                           back);
+    context.Close();
+    queue.ExecuteCommandList(context);
+
+    swap.Present();
+
+    WaitForGPU();
+}
+
+void Test::App::WaitForGPU()
+{
+    const uint64_t vfence = fence_value;
+    queue.Signal(fence, vfence);
+    fence_value++;
+    fence.Wait(vfence);
+}

--- a/examples/uniform-buffers-kdgui/app.h
+++ b/examples/uniform-buffers-kdgui/app.h
@@ -1,0 +1,47 @@
+#pragma once
+#include <wisdom/wisdom.h>
+#include "window.h"
+#include <optional>
+
+namespace Test {
+class App
+{
+public:
+    App(uint32_t width, uint32_t height);
+    ~App();
+
+public:
+    int Start();
+
+private:
+    void Frame();
+    void WaitForGPU();
+
+private:
+    XApp app;
+    Window wnd;
+
+    std::optional<wis::Factory> factory;
+
+    wis::Device device;
+    wis::CommandQueue queue;
+    wis::SwapChain swap;
+
+    wis::CommandList context;
+    wis::Fence fence;
+    wis::ResourceAllocator allocator;
+
+    wis::Shader vs;
+    wis::Shader ps;
+
+    wis::RootSignature root;
+    wis::PipelineState pipeline;
+    wis::VertexBufferView vb;
+    wis::RenderTargetView rtvs[2];
+    wis::RenderTargetView rtvs2[2];
+
+    wis::Resource vertex_buffer;
+    wis::RenderPass render_pass;
+    uint64_t fence_value = 1;
+};
+} // namespace Test

--- a/examples/uniform-buffers-kdgui/entry_main.cpp
+++ b/examples/uniform-buffers-kdgui/entry_main.cpp
@@ -1,0 +1,7 @@
+#include "app.h"
+
+int main()
+{
+    Test::App app(1920, 1080);
+    return app.Start();
+}

--- a/examples/uniform-buffers-kdgui/window.cpp
+++ b/examples/uniform-buffers-kdgui/window.cpp
@@ -62,11 +62,19 @@ wis::SurfaceParameters Window::GetSurfaceOptions() const noexcept
     };
 #elif defined(KD_PLATFORM_LINUX)
     if (KDGui::LinuxWaylandPlatformIntegration::checkAvailable()) {
+        auto *platformIntegration = KDGui::GuiApplication::instance()->guiPlatformIntegration();
+        auto *waylandPlatformIntegration = dynamic_cast<KDGui::LinuxWaylandPlatformIntegration *>(platformIntegration);
         auto waylandWindow = dynamic_cast<KDGui::LinuxWaylandPlatformWindow *>(p->platformWindow());
-        return wis::SurfaceParameters(waylandWindow->display(), waylandWindow->surface());
+        return wis::SurfaceParameters{
+            waylandPlatformIntegration->display(),
+            waylandWindow->surface(),
+        };
     } else {
-        auto xcbWindow = dynamic_cast<KDGui::LinuxXcbPlatformWindow *>(p->platformWindow());
-        return wis::SurfaceParameters(xcbWindow->connection(), xcbWindow->handle());
+        auto *xcbWindow = dynamic_cast<KDGui::LinuxXcbPlatformWindow *>(p->platformWindow());
+        return wis::SurfaceParameters{
+            xcbWindow->connection(),
+            xcbWindow->handle(),
+        };
     }
 #elif defined(KD_PLATFORM_MACOS)
     return wis::SurfaceParameters{

--- a/examples/uniform-buffers-kdgui/window.cpp
+++ b/examples/uniform-buffers-kdgui/window.cpp
@@ -63,16 +63,10 @@ wis::SurfaceParameters Window::GetSurfaceOptions() const noexcept
 #elif defined(KD_PLATFORM_LINUX)
     if (KDGui::LinuxWaylandPlatformIntegration::checkAvailable()) {
         auto waylandWindow = dynamic_cast<KDGui::LinuxWaylandPlatformWindow *>(p->platformWindow());
-        return wis::SurfaceParameters{
-            waylandWindow->display(),
-            waylandWindow->surface()
-        };
+        return wis::SurfaceParameters(waylandWindow->display(), waylandWindow->surface());
     } else {
         auto xcbWindow = dynamic_cast<KDGui::LinuxXcbPlatformWindow *>(p->platformWindow());
-        return wis::SurfaceParameters{
-            xcbWindow->connection(),
-            xcbWindow->handle()
-        };
+        return wis::SurfaceParameters(xcbWindow->connection(), xcbWindow->handle());
     }
 #elif defined(KD_PLATFORM_MACOS)
     return wis::SurfaceParameters{

--- a/examples/uniform-buffers-kdgui/window.cpp
+++ b/examples/uniform-buffers-kdgui/window.cpp
@@ -18,6 +18,8 @@
 #endif
 #if defined(KD_PLATFORM_LINUX)
 #include <KDGui/platform/linux/xcb/linux_xcb_platform_window.h>
+#include <KDGui/platform/linux/wayland/linux_wayland_platform_window.h>
+#include <KDGui/platform/linux/wayland/linux_wayland_platform_integration.h>
 #endif
 #if defined(KD_PLATFORM_MACOS)
 extern CAMetalLayer *createMetalLayer(KDGui::Window *window);
@@ -59,11 +61,19 @@ wis::SurfaceParameters Window::GetSurfaceOptions() const noexcept
         win32Window->handle()
     };
 #elif defined(KD_PLATFORM_LINUX)
-    auto xcbWindow = dynamic_cast<KDGui::LinuxXcbPlatformWindow *>(p->platformWindow());
-    return wis::SurfaceParameters{
-        xcbWindow->connection(),
-        xcbWindow->handle()
-    };
+    if (KDGui::LinuxWaylandPlatformIntegration::checkAvailable()) {
+        auto waylandWindow = dynamic_cast<KDGui::LinuxWaylandPlatformWindow *>(p->platformWindow());
+        return wis::SurfaceParameters{
+            waylandWindow->display(),
+            waylandWindow->surface()
+        };
+    } else {
+        auto xcbWindow = dynamic_cast<KDGui::LinuxXcbPlatformWindow *>(p->platformWindow());
+        return wis::SurfaceParameters{
+            xcbWindow->connection(),
+            xcbWindow->handle()
+        };
+    }
 #elif defined(KD_PLATFORM_MACOS)
     return wis::SurfaceParameters{
         .layer = createMetalLayer(this)

--- a/examples/uniform-buffers-kdgui/window.cpp
+++ b/examples/uniform-buffers-kdgui/window.cpp
@@ -1,0 +1,100 @@
+/*
+   This file is part of KDGpu.
+
+   SPDX-FileCopyrightText: 2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+
+   SPDX-License-Identifier: MIT
+
+   Contact KDAB at <info@kdab.com> for commercial licensing options.
+ */
+
+#include "window.h"
+
+#include <KDFoundation/config.h> // for KD_PLATFORM
+#include <KDGui/gui_application.h>
+
+#if defined(KD_PLATFORM_WIN32)
+#include <KDGui/platform/win32/win32_platform_window.h>
+#endif
+#if defined(KD_PLATFORM_LINUX)
+#include <KDGui/platform/linux/xcb/linux_xcb_platform_window.h>
+#endif
+#if defined(KD_PLATFORM_MACOS)
+extern CAMetalLayer *createMetalLayer(KDGui::Window *window);
+#endif
+
+#include <KDGui/window.h>
+#include <KDGui/gui_application.h>
+
+class WindowP : public KDGui::Window
+{
+};
+
+Window::Window(uint32_t width, uint32_t height, WindowP *p)
+    : p(p)
+{
+    p->width = 1920;
+    p->height = 1080;
+    p->visible = true;
+}
+Window::~Window()
+{
+    p->destroy();
+}
+
+uint32_t Window::width() const noexcept
+{
+    return p->width.get();
+}
+uint32_t Window::height() const noexcept
+{
+    return p->height.get();
+}
+
+wis::SurfaceParameters Window::GetSurfaceOptions() const noexcept
+{
+#if defined(KD_PLATFORM_WIN32)
+    auto win32Window = dynamic_cast<KDGui::Win32PlatformWindow *>(p->platformWindow());
+    return wis::SurfaceParameters{
+        win32Window->handle()
+    };
+#elif defined(KD_PLATFORM_LINUX)
+    auto xcbWindow = dynamic_cast<KDGui::LinuxXcbPlatformWindow *>(p->platformWindow());
+    return wis::SurfaceParameters{
+        xcbWindow->connection(),
+        xcbWindow->handle()
+    };
+#elif defined(KD_PLATFORM_MACOS)
+    return wis::SurfaceParameters{
+        .layer = createMetalLayer(this)
+    };
+#endif
+    return {};
+}
+bool Window::visible() const noexcept
+{
+    return p->visible.get();
+}
+
+class XAppP
+{
+public:
+    KDGui::GuiApplication app;
+};
+
+XApp::XApp()
+    : p(new XAppP())
+{
+}
+XApp::~XApp()
+{
+}
+
+void XApp::ProcessEvents()
+{
+    p->app.processEvents();
+}
+Window XApp::createWindow(uint32_t width, uint32_t height)
+{
+    return Window(width, height, p->app.createChild<WindowP>());
+}

--- a/examples/uniform-buffers-kdgui/window.h
+++ b/examples/uniform-buffers-kdgui/window.h
@@ -1,0 +1,49 @@
+/*
+  This file is part of KDGpu.
+
+  SPDX-FileCopyrightText: 2023 Klarälvdalens Datakonsult AB, a KDAB Group company <info@kdab.com>
+
+  SPDX-License-Identifier: MIT
+
+  Contact KDAB at <info@kdab.com> for commercial licensing options.
+*/
+
+#pragma once
+#include <wisdom/api/api_swapchain.h>
+#include <memory>
+
+class WindowP;
+class Window
+{
+    friend class XApp;
+
+private:
+    Window(uint32_t width, uint32_t height, WindowP *p);
+
+public:
+    ~Window();
+
+public:
+    bool visible() const noexcept;
+    uint32_t width() const noexcept;
+    uint32_t height() const noexcept;
+    wis::SurfaceParameters GetSurfaceOptions() const noexcept;
+    // KDGpu::Surface createSurface(KDGpu::Instance& instance);
+private:
+    WindowP *p;
+};
+
+class XAppP;
+class XApp
+{
+public:
+    XApp();
+    ~XApp();
+
+public:
+    void ProcessEvents();
+    Window createWindow(uint32_t width, uint32_t height);
+
+private:
+    std::unique_ptr<XAppP> p;
+};

--- a/plugins/CMakeLists.txt
+++ b/plugins/CMakeLists.txt
@@ -32,6 +32,7 @@ find_package(Vulkan)
 
 # UWP not supported
 if(Vulkan_FOUND AND NOT WINDOWS_STORE)
+    add_subdirectory("VKHpp")
 	add_subdirectory("VKAllocator")
 endif()
 

--- a/plugins/DX12Allocator/CMakeLists.txt
+++ b/plugins/DX12Allocator/CMakeLists.txt
@@ -29,6 +29,6 @@ target_include_directories(${PROJECT_NAME}
 )
 set_target_properties(${PROJECT_NAME}
     	PROPERTIES
-		    CXX_STANDARD 23
+		    CXX_STANDARD 20
 )
 target_install(${PROJECT_NAME})

--- a/plugins/DXC/CMakeLists.txt
+++ b/plugins/DXC/CMakeLists.txt
@@ -2,7 +2,7 @@ project(DXC)
 
 cmake_policy(SET CMP0135 NEW)
 
-if(NOT PLUGINS_LOADED)
+if((NOT PLUGINS_LOADED) AND (NOT WISDOM_USE_SYSTEM_DXC))
     message("Loading DXC...")
 
     # Download latest DXC from AppVeyor
@@ -24,4 +24,6 @@ if(NOT PLUGINS_LOADED)
     else()
         set(dxc_EXECUTABLE ${dxc_SOURCE_DIR}/bin/dxc CACHE INTERNAL "")
     endif()
+elseif(WISDOM_USE_SYSTEM_DXC)
+    set(dxc_EXECUTABLE "dxc" CACHE INTERNAL "")
 endif()

--- a/plugins/VKAllocator/CMakeLists.txt
+++ b/plugins/VKAllocator/CMakeLists.txt
@@ -17,7 +17,7 @@ if(NOT PLUGINS_LOADED)
 	  vkmahpp
 	  GIT_REPOSITORY https://github.com/YaaZ/VulkanMemoryAllocator-Hpp.git
 	  GIT_TAG origin/master
-      GIT_SUBMODULES "VulkanMemoryAllocator" "Vulkan-Hpp"
+      GIT_SUBMODULES "include"
 	)
 	FetchContent_GetProperties(vkmahpp)
 	if(NOT vkmahpp_POPULATED)
@@ -34,13 +34,6 @@ target_sources(${PROJECT_NAME}
 		${vkma_SOURCES}/src/VmaUsage.cpp
 		${vkma_SOURCES}/src/VmaUsage.h
 )
-
-if (CMAKE_SYSTEM_NAME STREQUAL "Linux")
-    # TODO: find a better way to do this
-    # TODO: find ANY way to do this
-    add_compile_definitions(VK_USE_PLATFORM_WAYLAND_KHR)
-    target_compile_definitions(${PROJECT_NAME} PRIVATE VK_USE_PLATFORM_WAYLAND_KHR)
-endif()
 
 if (MSVC)
 	# Provides MSVC users nicer debugging support

--- a/plugins/VKAllocator/CMakeLists.txt
+++ b/plugins/VKAllocator/CMakeLists.txt
@@ -12,17 +12,18 @@ if(NOT PLUGINS_LOADED)
 	  FetchContent_Populate(vkma)
 	endif()
 	set(vkma_SOURCES ${vkma_SOURCE_DIR} CACHE INTERNAL "")
-	
+
 	FetchContent_Declare(
 	  vkmahpp
 	  GIT_REPOSITORY https://github.com/YaaZ/VulkanMemoryAllocator-Hpp.git
 	  GIT_TAG origin/master
-	  GIT_SUBMODULES "include"
+      GIT_SUBMODULES "VulkanMemoryAllocator" "Vulkan-Hpp"
 	)
 	FetchContent_GetProperties(vkmahpp)
 	if(NOT vkmahpp_POPULATED)
 	  FetchContent_Populate(vkmahpp)
 	endif()
+
 	set(vkmahpp_SOURCES ${vkmahpp_SOURCE_DIR} CACHE INTERNAL "")
 endif()
 
@@ -33,6 +34,14 @@ target_sources(${PROJECT_NAME}
 		${vkma_SOURCES}/src/VmaUsage.cpp
 		${vkma_SOURCES}/src/VmaUsage.h
 )
+
+if (CMAKE_SYSTEM_NAME STREQUAL "Linux")
+    # TODO: find a better way to do this
+    # TODO: find ANY way to do this
+    add_compile_definitions(VK_USE_PLATFORM_WAYLAND_KHR)
+    target_compile_definitions(${PROJECT_NAME} PRIVATE VK_USE_PLATFORM_WAYLAND_KHR)
+endif()
+
 if (MSVC)
 	# Provides MSVC users nicer debugging support
 	target_sources(${PROJECT_NAME} PRIVATE ${vkma_SOURCES}/src/vk_mem_alloc.natvis)

--- a/plugins/VKAllocator/CMakeLists.txt
+++ b/plugins/VKAllocator/CMakeLists.txt
@@ -5,7 +5,7 @@ if(NOT PLUGINS_LOADED)
 	FetchContent_Declare(
 	  vkma
 	  GIT_REPOSITORY https://github.com/GPUOpen-LibrariesAndSDKs/VulkanMemoryAllocator.git
-	  GIT_TAG origin/master
+	  GIT_TAG 3cb5470faabaf1c1ab7b60828ad8f33f22be0424
 	)
 	FetchContent_GetProperties(vkma)
 	if(NOT vkma_POPULATED)

--- a/plugins/VKAllocator/CMakeLists.txt
+++ b/plugins/VKAllocator/CMakeLists.txt
@@ -55,6 +55,6 @@ target_include_directories(${PROJECT_NAME}
 )
 set_target_properties(${PROJECT_NAME}
 		PROPERTIES
-			CXX_STANDARD 23
+			CXX_STANDARD 20
 )
 target_install(${PROJECT_NAME})

--- a/plugins/VKHpp/CMakeLists.txt
+++ b/plugins/VKHpp/CMakeLists.txt
@@ -1,0 +1,24 @@
+project(VKHpp)
+
+if (NOT PLUGINS_LOADED)
+    message("Loading vulkan-hpp headers...")
+	FetchContent_Declare(
+	  vulkanhpp
+      GIT_REPOSITORY https://github.com/Agrael1/Vulkan-Hpp
+      GIT_TAG main
+      GIT_SUBMODULES ""
+	)
+	FetchContent_GetProperties(vulkanhpp)
+	if(NOT vulkanhpp_POPULATED)
+	  FetchContent_Populate(vulkanhpp)
+	endif()
+endif()
+
+add_library(${PROJECT_NAME} INTERFACE)
+target_include_directories(${PROJECT_NAME} SYSTEM BEFORE 
+    INTERFACE         
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/include>
+        $<INSTALL_INTERFACE:include>
+)
+
+target_install_interface(${PROJECT_NAME})

--- a/wisdom/CMakeLists.txt
+++ b/wisdom/CMakeLists.txt
@@ -70,7 +70,7 @@ target_include_directories(${PROJECT_NAME} PUBLIC
 )
 set_target_properties(${PROJECT_NAME} 
 	PROPERTIES
-		CXX_STANDARD 23
+		CXX_STANDARD 20
 )
 target_compile_definitions(${PROJECT_NAME} 
 	PUBLIC

--- a/wisdom/include/wisdom/api/api_swapchain.h
+++ b/wisdom/include/wisdom/api/api_swapchain.h
@@ -6,6 +6,8 @@
 #endif // WISDOM_WINDOWS
 #ifdef WISDOM_LINUX
 #include <xcb/xproto.h>
+struct wl_display;
+struct wl_surface;
 #endif // WISDOM_LINUX
 
 #include <wisdom/api/api_common.h>
@@ -53,6 +55,7 @@ WIS_EXPORT namespace wis
 			WinRT,
 			X11,
 			Metal,
+            Wayland
 		};
 	public:
 		SurfaceParameters() = default;
@@ -77,6 +80,13 @@ WIS_EXPORT namespace wis
 		explicit SurfaceParameters(xcb_connection_t* connection, xcb_window_t window)
 			:type(Type::X11), x11{ connection, window }
 		{}
+        
+        /// @brief Create a surface parameters struct for a wayland window.
+        /// @param display wayland display handle
+        /// @param surface wayland surface handle
+        explicit SurfaceParameters(wl_display* display,  wl_surface* surface)
+			:type(Type::Wayland), wayland{ display, surface }
+		{}
 #endif
 #if WISDOM_MACOS
 		/// @brief Create a surface parameters for a Metal layer.
@@ -85,14 +95,6 @@ WIS_EXPORT namespace wis
 			:type(Type::Metal), layer(layer)
 		{}
 #endif
-	public:
-		/// @brief Check if the surface is WinRT CoreWindow.
-		/// @return true if the surface is WinRT CoreWindow.
-		[[nodiscard]]
-		bool IsWinRT()const noexcept
-		{
-			return type == Type::WinRT;
-		}
 	public:
 		Type type = Type::None; //< Type of the surface.
 		union
@@ -109,6 +111,10 @@ WIS_EXPORT namespace wis
 				xcb_connection_t* connection; //< X11 connection.
 				xcb_window_t window; //< X11 window handle.
 		}x11; //< X11 window.
+            struct {
+                wl_display* display;
+                wl_surface* surface;
+            } wayland;
 #endif // WISDOM_LINUX
 #if WISDOM_MACOS
 			CAMetalLayer* layer; //< Metal layer.

--- a/wisdom/include/wisdom/vulkan/impl/vk_factory.inl
+++ b/wisdom/include/wisdom/vulkan/impl/vk_factory.inl
@@ -1,5 +1,5 @@
 #ifndef WISDOM_MODULES
-//#include <wisdom/vulkan/vk_factory.h>
+#include <wisdom/vulkan/vk_factory.h>
 #include <ranges>
 #include <unordered_map>
 #include <wisdom/util/misc.h>
@@ -81,12 +81,16 @@ namespace
 		VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME,
 	#if defined(VK_USE_PLATFORM_WIN32_KHR)
 		VK_KHR_WIN32_SURFACE_EXTENSION_NAME,
-	#elif defined(VK_USE_PLATFORM_XCB_KHR)
-		VK_KHR_XCB_SURFACE_EXTENSION_NAME,
 	#elif defined(VK_USE_PLATFORM_METAL_EXT)
 		VK_EXT_METAL_SURFACE_EXTENSION_NAME,
 		VK_KHR_PORTABILITY_ENUMERATION_EXTENSION_NAME
 	#endif
+    #if defined(VK_USE_PLATFORM_XCB_KHR)
+		VK_KHR_XCB_SURFACE_EXTENSION_NAME,
+    #endif
+    #if defined(VK_USE_PLATFORM_WAYLAND_KHR)
+		VK_KHR_WAYLAND_SURFACE_EXTENSION_NAME,
+    #endif
 	#if DEBUG_MODE
 		VK_EXT_DEBUG_REPORT_EXTENSION_NAME,
 		VK_EXT_DEBUG_UTILS_EXTENSION_NAME

--- a/wisdom/include/wisdom/vulkan/vk_device.h
+++ b/wisdom/include/wisdom/vulkan/vk_device.h
@@ -286,7 +286,7 @@ WIS_EXPORT namespace wis
 		)const noexcept;
 	private:
 		QueueResidency queues{};
-		bool vrs_supported : 1 = false;
+		// bool vrs_supported : 1 = false;
 		bool mesh_shader_supported : 1 = false;
 		bool ray_tracing_supported : 1 = false;
 		bool ray_query_supported : 1 = false;


### PR DESCRIPTION
Wisdom will resolve wayland vs. xcb at runtime.

Also includes the initialization of the uniform buffer example, currently identical to the hello triangle kdgui example.

Also a downgrade to C++20 from 23.

Also the addition of a .clang-format.

Should I have made separate PRs? Probably.