### PR TITLE
The Great Formatting

### DIFF
--- a/.clang-format.sh
+++ b/.clang-format.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+
+FORMAT_TARGETS=("wisdom" "examples")
+
+function format() {
+    for f in $(find $@ -name '*.h' -or -name '*.inl' -or -name '*.ixx' -or -name '*.m' -or -name '*.mm' -or -name '*.c' -or -name '*.cpp'); do 
+        echo "format ${f}";
+        clang-format -i ${f};
+    done
+
+    echo "~~~ $@ Done ~~~";
+}
+
+for dir in "$FORMAT_TARGETS"; do
+    if [ -d "${dir}" ]; then
+        format ${dir};
+    fi
+done

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,0 +1,23 @@
+---
+Checks:          'clang-diagnostic-*,clang-analyzer-*,-clang-analyzer-alpha*,*,-google-*,-cppcoreguidelines-*,-readability-else-after-return,-readability-implicit-bool-cast,-llvmlibc-*,-llvm-include-order,-readability-named-parameter,-readabilty-namespace-comments,-llvm-namespace-comment,-clang-analyzer-alpha.core.CastToStruct,-modernize-use-override,-modernize-use-bool-literals,-clang-analyzer-cplusplus.NewDeleteLeaks,-clang-analyzer-alpha.deadcode.UnreachableCode,-modernize-use-default,-clang-analyzer-core.CallAndMessage,-modernize-pass-by-value,-clang-analyzer-core.NonNullParamChecker,-modernize-raw-string-literal,-modernize-use-using,-modernize-loop-convert,-modernize-use-emplace,-modernize-return-braced-init-list,-modernize-use-default-member-init,-modernize-use-equals-default,-fuchsia-*,-hicpp-*,-readability-implicit-bool-conversioni,-altera-unroll-loops,-modernize-use-trailing-return-type,-altera-struct-pack-align,-readability-identifier-length,-readability-uppercase-literal-suffix,-altera-id-dependent-backward-branch,-readability-isolate-declaration,-cert-msc32-c,-misc-non-private-member-variables-in-classes,-bugprone-easily-swappable-parameters,-llvm-else-after-return,-bugprone-lambda-function-name,-modernize-avoid-c-arrays'
+WarningsAsErrors: ''
+HeaderFilterRegex: ''
+AnalyzeTemporaryDtors: false
+CheckOptions:
+  - key:             cert-oop11-cpp.UseCERTSemantics
+    value:           '1'
+  - key:             modernize-loop-convert.MaxCopySize
+    value:           '16'
+  - key:             modernize-loop-convert.MinConfidence
+    value:           reasonable
+  - key:             modernize-loop-convert.NamingStyle
+    value:           CamelCase
+  - key:             modernize-pass-by-value.IncludeStyle
+    value:           llvm
+  - key:             modernize-replace-auto-ptr.IncludeStyle
+    value:           llvm
+  - key:             modernize-use-nullptr.NullMacros
+    value:           'NULL'
+  - key:             readability-braces-around-statements.ShortStatementLines
+    value:           '3'
+...

--- a/examples/.clang-tidy
+++ b/examples/.clang-tidy
@@ -1,0 +1,5 @@
+---
+# this file primarily removes checks that would prevent us from doing math with
+# numbers like a normal person
+Checks: '-readability-magic-numbers'
+InheritParentConfig: true

--- a/examples/hello-triangle-kdgui/app.cpp
+++ b/examples/hello-triangle-kdgui/app.cpp
@@ -76,7 +76,6 @@ Test::App::App(uint32_t width, uint32_t height)
 
     OnResize(width, height);
 
-
     struct Vertex {
         glm::vec3 pos;
         glm::vec4 col;
@@ -146,7 +145,7 @@ void Test::App::Frame()
     context.IASetPrimitiveTopology(wis::PrimitiveTopology::trianglelist);
     context.IASetVertexBuffers({ &vb, 1 });
 
-    context.BeginRenderPass(render_pass, { rtvsx.data(), swap.StereoSupported() + 1u });
+    context.BeginRenderPass(render_pass, { rtvsx.data(), static_cast<unsigned int>(swap.StereoSupported()) + 1u });
     context.DrawInstanced(3);
     context.EndRenderPass();
 
@@ -200,7 +199,7 @@ void Test::App::OnResize(uint32_t width, uint32_t height)
     desc.SetVS(vs);
     desc.SetPS(ps);
     desc.SetRenderPass(render_pass);
-    pipeline = device.CreateGraphicsPipeline(std::move(desc), ia);
+    pipeline = device.CreateGraphicsPipeline(desc, ia);
     context.SetPipeline(pipeline);
 
     auto x = swap.GetRenderTargets();
@@ -210,4 +209,3 @@ void Test::App::OnResize(uint32_t width, uint32_t height)
             rtvs2[i] = device.CreateRenderTargetView(x[i], { .base_layer = 1 });
     }
 }
-

--- a/examples/hello-triangle-kdgui/app.h
+++ b/examples/hello-triangle-kdgui/app.h
@@ -10,7 +10,6 @@ public:
     App(uint32_t width, uint32_t height);
     ~App();
 
-public:
     int Start();
 
 private:
@@ -18,7 +17,6 @@ private:
     void WaitForGPU();
     void OnResize(uint32_t width, uint32_t height);
 
-private:
     XApp app;
     Window wnd;
 

--- a/examples/hello-triangle-kdgui/entry_main.cpp
+++ b/examples/hello-triangle-kdgui/entry_main.cpp
@@ -2,6 +2,6 @@
 
 int main()
 {
-	Test::App app(1920, 1080);
-	return app.Start();
+    Test::App app(1920, 1080);
+    return app.Start();
 }

--- a/examples/hello-triangle-kdgui/window.cpp
+++ b/examples/hello-triangle-kdgui/window.cpp
@@ -42,8 +42,8 @@ public:
 Window::Window(uint32_t width, uint32_t height, WindowP *p)
     : p(p)
 {
-    p->width = 1920;
-    p->height = 1080;
+    p->width = width;
+    p->height = height;
     p->visible = true;
 }
 Window::~Window()
@@ -71,7 +71,7 @@ wis::SurfaceParameters Window::GetSurfaceOptions() const noexcept
     if (KDGui::LinuxWaylandPlatformIntegration::checkAvailable()) {
         auto *platformIntegration = KDGui::GuiApplication::instance()->guiPlatformIntegration();
         auto *waylandPlatformIntegration = dynamic_cast<KDGui::LinuxWaylandPlatformIntegration *>(platformIntegration);
-        auto waylandWindow = dynamic_cast<KDGui::LinuxWaylandPlatformWindow *>(p->platformWindow());
+        auto *waylandWindow = dynamic_cast<KDGui::LinuxWaylandPlatformWindow *>(p->platformWindow());
         return wis::SurfaceParameters{
             waylandPlatformIntegration->display(),
             waylandWindow->surface(),

--- a/examples/hello-triangle-kdgui/window.h
+++ b/examples/hello-triangle-kdgui/window.h
@@ -12,36 +12,37 @@
 #include <wisdom/api/api_swapchain.h>
 #include <memory>
 
-
 class WindowP;
 class Window
 {
-	friend class XApp;
+    friend class XApp;
+
 private:
-	Window(uint32_t width, uint32_t height, WindowP* p);
+    Window(uint32_t width, uint32_t height, WindowP *p);
+
 public:
-	~Window();
-public:
-	bool visible()const noexcept;
-	uint32_t width()const noexcept;
-	uint32_t height()const noexcept;
-	wis::SurfaceParameters GetSurfaceOptions()const noexcept;
-	bool resized()const noexcept;
-	//KDGpu::Surface createSurface(KDGpu::Instance& instance);
+    ~Window();
+
+    [[nodiscard]] bool visible() const noexcept;
+    [[nodiscard]] uint32_t width() const noexcept;
+    [[nodiscard]] uint32_t height() const noexcept;
+    [[nodiscard]] wis::SurfaceParameters GetSurfaceOptions() const noexcept;
+    [[nodiscard]] bool resized() const noexcept;
+    // KDGpu::Surface createSurface(KDGpu::Instance& instance);
 private:
-	WindowP* p;
+    WindowP *p;
 };
 
 class XAppP;
 class XApp
 {
 public:
-	XApp();
-	~XApp();
-public:
-	void ProcessEvents();
-	Window createWindow(uint32_t width, uint32_t height);
-private:
-	std::unique_ptr<XAppP> p;
-};
+    XApp();
+    ~XApp();
 
+    void ProcessEvents();
+    Window createWindow(uint32_t width, uint32_t height);
+
+private:
+    std::unique_ptr<XAppP> p;
+};

--- a/examples/hello-triangle-modules/app.ixx
+++ b/examples/hello-triangle-modules/app.ixx
@@ -1,5 +1,5 @@
 module;
-#if !defined(WISDOM_WINDOWS) || defined(WISDOM_VULKAN_FOUND) && defined(WISDOM_FORCE_VULKAN) 
+#if !defined(WISDOM_WINDOWS) || defined(WISDOM_VULKAN_FOUND) && defined(WISDOM_FORCE_VULKAN)
 #include <vulkan/vulkan.hpp>
 #endif
 
@@ -16,252 +16,236 @@ export module app;
 import wisdom;
 import window;
 
-
 export class App
 {
 public:
-	App(uint32_t width, uint32_t height);
-	~App();
+    App(uint32_t width, uint32_t height);
+    ~App();
+
 public:
-	int Start();
+    int Start();
+
 private:
-	void Frame();
-	void WaitForGPU();
+    void Frame();
+    void WaitForGPU();
+
 private:
-	XApp app;
-	Window wnd;
+    XApp app;
+    Window wnd;
 
-	std::optional<wis::Factory> factory;
+    std::optional<wis::Factory> factory;
 
-	wis::Device device;
-	wis::CommandQueue queue;
-	wis::SwapChain swap;
+    wis::Device device;
+    wis::CommandQueue queue;
+    wis::SwapChain swap;
 
-	wis::CommandList context;
-	wis::Fence fence;
-	wis::ResourceAllocator allocator;
+    wis::CommandList context;
+    wis::Fence fence;
+    wis::ResourceAllocator allocator;
 
-	wis::Shader vs;
-	wis::Shader ps;
+    wis::Shader vs;
+    wis::Shader ps;
 
-	wis::RootSignature root;
-	wis::PipelineState pipeline;
-	wis::VertexBufferView vb;
-	wis::RenderTargetView rtvs[2];
-	wis::RenderTargetView rtvs2[2];
+    wis::RootSignature root;
+    wis::PipelineState pipeline;
+    wis::VertexBufferView vb;
+    wis::RenderTargetView rtvs[2];
+    wis::RenderTargetView rtvs2[2];
 
-	wis::Resource vertex_buffer;
-	wis::RenderPass render_pass;
-	uint64_t fence_value = 1;
+    wis::Resource vertex_buffer;
+    wis::RenderPass render_pass;
+    uint64_t fence_value = 1;
 };
 
-struct LogProvider : public wis::LogLayer
-{
-	virtual void Log(wis::Severity sev, std::string message, wis::source_location sl = wis::source_location::current())override
-	{
-		std::cout << wis::format("[{}]: {}\n", wis::severity_strings[uint32_t(sev)], message);
-	};
+struct LogProvider : public wis::LogLayer {
+    virtual void Log(wis::Severity sev, std::string message, wis::source_location sl = wis::source_location::current()) override
+    {
+        std::cout << wis::format("[{}]: {}\n", wis::severity_strings[uint32_t(sev)], message);
+    };
 };
 
 constexpr wis::ApplicationInfo app_info{
-	.application_name = "example",
-		.engine_name = "none",
+    .application_name = "example",
+    .engine_name = "none",
 };
 
 // not WinRT Compatible
 template<class ShaderTy>
 auto LoadShader(std::filesystem::path p)
 {
-	if constexpr (ShaderTy::language == wis::ShaderLang::dxil)
-		p += ".cso";
-	else if constexpr (ShaderTy::language == wis::ShaderLang::spirv)
-		p += ".spv";
+    if constexpr (ShaderTy::language == wis::ShaderLang::dxil)
+        p += ".cso";
+    else if constexpr (ShaderTy::language == wis::ShaderLang::spirv)
+        p += ".spv";
 
-	std::ifstream t{ p, std::ios::binary };
-	t.seekg(0, std::ios::end);
-	size_t size = t.tellg();
-	wis::shared_blob ret{ size };
-	t.seekg(0);
-	t.read(ret.data<char>(), size);
-	return ret;
+    std::ifstream t{ p, std::ios::binary };
+    t.seekg(0, std::ios::end);
+    size_t size = t.tellg();
+    wis::shared_blob ret{ size };
+    t.seekg(0);
+    t.read(ret.data<char>(), size);
+    return ret;
 }
 
 template<class T>
-std::span<std::byte> RawView(T& data)
+std::span<std::byte> RawView(T &data)
 {
-	return { (std::byte*)&data, sizeof(T) };
+    return { (std::byte *)&data, sizeof(T) };
 }
 
-
 App::App(uint32_t width, uint32_t height)
-	:wnd(app.createWindow(width, height))
+    : wnd(app.createWindow(width, height))
 {
-	wis::LibLogger::SetLogLayer(std::make_shared<LogProvider>());
+    wis::LibLogger::SetLogLayer(std::make_shared<LogProvider>());
 
-	factory.emplace(app_info);
-	for (auto&& a : factory->EnumerateAdapters(wis::AdapterPreference::Performance))
-	{
-		auto desc = a.GetDesc();
+    factory.emplace(app_info);
+    for (auto &&a : factory->EnumerateAdapters(wis::AdapterPreference::Performance)) {
+        auto desc = a.GetDesc();
 
-		if (desc.IsSoftware())
-			wis::lib_warn("Loading WARP adapter");
+        if (desc.IsSoftware())
+            wis::lib_warn("Loading WARP adapter");
 
-		std::cout << desc.to_string();
+        std::cout << desc.to_string();
 
-		if (device.Initialize(a))
-		{
-			allocator = wis::ResourceAllocator{ device, a };
-			break;
-		}
-	}
+        if (device.Initialize(a)) {
+            allocator = wis::ResourceAllocator{ device, a };
+            break;
+        }
+    }
 
-	queue = device.CreateCommandQueue();
+    queue = device.CreateCommandQueue();
 
-	swap = device.CreateSwapchain(queue, wis::SwapchainOptions{
-			uint32_t(width),
-			uint32_t(height),
-			wis::SwapchainOptions::default_frames,
-			wis::SwapchainOptions::default_format,
-			true
-		}, wnd.GetSurfaceOptions());
+    swap = device.CreateSwapchain(queue, wis::SwapchainOptions{ uint32_t(width), uint32_t(height), wis::SwapchainOptions::default_frames, wis::SwapchainOptions::default_format, true }, wnd.GetSurfaceOptions());
 
-	fence = device.CreateFence();
-	context = device.CreateCommandList(wis::QueueType::direct);
+    fence = device.CreateFence();
+    context = device.CreateCommandList(wis::QueueType::direct);
 
-	std::array cas2{
-		wis::ColorAttachment {
-			.format = wis::SwapchainOptions::default_format,
-				.load = wis::PassLoadOperation::clear
-		},
-		wis::ColorAttachment {
-			.format = wis::SwapchainOptions::default_format,
-				.load = wis::PassLoadOperation::clear
-		}
-	};
+    std::array cas2{
+        wis::ColorAttachment{
+                .format = wis::SwapchainOptions::default_format,
+                .load = wis::PassLoadOperation::clear },
+        wis::ColorAttachment{
+                .format = wis::SwapchainOptions::default_format,
+                .load = wis::PassLoadOperation::clear }
+    };
 
-	render_pass = device.CreateRenderPass({ width, height }, { cas2.data(), swap.StereoSupported() + 1u });
+    render_pass = device.CreateRenderPass({ width, height }, { cas2.data(), swap.StereoSupported() + 1u });
 
-	vs = device.CreateShader(LoadShader<wis::Shader>(SHADER_DIR "/example.vs"), wis::ShaderType::vertex);
-	ps = device.CreateShader(LoadShader<wis::Shader>(SHADER_DIR "/example.ps"), wis::ShaderType::pixel);
+    vs = device.CreateShader(LoadShader<wis::Shader>(SHADER_DIR "/example.vs"), wis::ShaderType::vertex);
+    ps = device.CreateShader(LoadShader<wis::Shader>(SHADER_DIR "/example.ps"), wis::ShaderType::pixel);
 
-	root = device.CreateRootSignature();//empty
+    root = device.CreateRootSignature(); // empty
 
-	static constexpr std::array<wis::InputLayoutDesc, 2> ia{
-		wis::InputLayoutDesc{ 0, "POSITION", 0, wis::DataFormat::r32g32b32_float, 0, 0, wis::InputClassification::vertex, 0 },
-		wis::InputLayoutDesc{ 1, "COLOR", 0, wis::DataFormat::r32g32b32a32_float, 0, 12, wis::InputClassification::vertex, 0 }
-	};
+    static constexpr std::array<wis::InputLayoutDesc, 2> ia{
+        wis::InputLayoutDesc{ 0, "POSITION", 0, wis::DataFormat::r32g32b32_float, 0, 0, wis::InputClassification::vertex, 0 },
+        wis::InputLayoutDesc{ 1, "COLOR", 0, wis::DataFormat::r32g32b32a32_float, 0, 12, wis::InputClassification::vertex, 0 }
+    };
 
-	wis::GraphicsPipelineDesc desc{ root };
-	desc.SetVS(vs);
-	desc.SetPS(ps);
-	desc.SetRenderPass(render_pass);
-	pipeline = device.CreateGraphicsPipeline(std::move(desc), ia);
+    wis::GraphicsPipelineDesc desc{ root };
+    desc.SetVS(vs);
+    desc.SetPS(ps);
+    desc.SetRenderPass(render_pass);
+    pipeline = device.CreateGraphicsPipeline(std::move(desc), ia);
 
-	struct Vertex
-	{
-		glm::vec3 pos;
-		glm::vec4 col;
-	};
-	auto aspect_ratio = float(width) / float(height);
-	Vertex triangleVertices[] =
-	{
-		{ { 0.0f, 0.25f * aspect_ratio , 0.0f }, { 1.0f, 0.0f, 0.0f, 1.0f } },
-		{ { 0.25f, -0.25f * aspect_ratio , 0.0f }, { 0.0f, 1.0f, 0.0f, 1.0f } },
-		{ { -0.25f, -0.25f * aspect_ratio , 0.0f }, { 0.0f, 0.0f, 1.0f, 1.0f } }
-	};
+    struct Vertex {
+        glm::vec3 pos;
+        glm::vec4 col;
+    };
+    auto aspect_ratio = float(width) / float(height);
+    Vertex triangleVertices[] = {
+        { { 0.0f, 0.25f * aspect_ratio, 0.0f }, { 1.0f, 0.0f, 0.0f, 1.0f } },
+        { { 0.25f, -0.25f * aspect_ratio, 0.0f }, { 0.0f, 1.0f, 0.0f, 1.0f } },
+        { { -0.25f, -0.25f * aspect_ratio, 0.0f }, { 0.0f, 0.0f, 1.0f, 1.0f } }
+    };
 
-	vertex_buffer = allocator.CreatePersistentBuffer(sizeof(triangleVertices), wis::BufferFlags::VertexBuffer);
+    vertex_buffer = allocator.CreatePersistentBuffer(sizeof(triangleVertices), wis::BufferFlags::VertexBuffer);
 
-	auto upl_vbuf = allocator.CreateUploadBuffer(sizeof(triangleVertices));
-	upl_vbuf.UpdateSubresource(RawView(triangleVertices));
+    auto upl_vbuf = allocator.CreateUploadBuffer(sizeof(triangleVertices));
+    upl_vbuf.UpdateSubresource(RawView(triangleVertices));
 
-	context.Reset();
-	context.CopyBuffer(upl_vbuf, vertex_buffer, sizeof(triangleVertices));
-	context.BufferBarrier({
-		.access_before = wis::ResourceAccess::CopyDest,
-		.access_after = wis::ResourceAccess::VertexBuffer
-		}, vertex_buffer);
-	context.Close();
+    context.Reset();
+    context.CopyBuffer(upl_vbuf, vertex_buffer, sizeof(triangleVertices));
+    context.BufferBarrier({ .access_before = wis::ResourceAccess::CopyDest,
+                            .access_after = wis::ResourceAccess::VertexBuffer },
+                          vertex_buffer);
+    context.Close();
 
-	queue.ExecuteCommandList(context);
-	WaitForGPU();
+    queue.ExecuteCommandList(context);
+    WaitForGPU();
 
-	vb = vertex_buffer.GetVertexBufferView(sizeof(Vertex));
-	context.SetPipeline(pipeline);
+    vb = vertex_buffer.GetVertexBufferView(sizeof(Vertex));
+    context.SetPipeline(pipeline);
 
-	auto x = swap.GetRenderTargets();
-	for (size_t i = 0; i < x.size(); i++)
-	{
-		rtvs[i] = device.CreateRenderTargetView(x[i]);
-		if (swap.StereoSupported())
-			rtvs2[i] = device.CreateRenderTargetView(x[i], { .base_layer = 1 });
-	}
+    auto x = swap.GetRenderTargets();
+    for (size_t i = 0; i < x.size(); i++) {
+        rtvs[i] = device.CreateRenderTargetView(x[i]);
+        if (swap.StereoSupported())
+            rtvs2[i] = device.CreateRenderTargetView(x[i], { .base_layer = 1 });
+    }
 }
 App::~App()
 {
-	WaitForGPU();
+    WaitForGPU();
 }
 
 int App::Start()
 {
-	while (true)
-	{
-		app.ProcessEvents();
-		if (!wnd.visible())
-			return 0;
-		//Process Events
+    while (true) {
+        app.ProcessEvents();
+        if (!wnd.visible())
+            return 0;
+        // Process Events
 
-		Frame();
-	}
+        Frame();
+    }
 }
 void App::Frame()
 {
-	context.Reset();
-	auto back = swap.GetBackBuffer();
+    context.Reset();
+    auto back = swap.GetBackBuffer();
 
-	context.TextureBarrier({
-		.state_before = wis::TextureState::Present,
-		.state_after = wis::TextureState::RenderTarget,
-		.access_before = wis::ResourceAccess::Common,
-		.access_after = wis::ResourceAccess::RenderTarget
-		}, back);
+    context.TextureBarrier({ .state_before = wis::TextureState::Present,
+                             .state_after = wis::TextureState::RenderTarget,
+                             .access_before = wis::ResourceAccess::Common,
+                             .access_after = wis::ResourceAccess::RenderTarget },
+                           back);
 
-	constexpr wis::ColorClear color{ 0.0f, 0.2f, 0.4f, 1.0f };
-	constexpr wis::ColorClear color2{ 1.0f, 0.2f, 0.4f, 1.0f };
-	std::array rtvsx{
-		std::pair{rtvs[swap.GetNextIndex()], color},
-		std::pair{rtvs2[swap.GetNextIndex()], color2}
-	};
+    constexpr wis::ColorClear color{ 0.0f, 0.2f, 0.4f, 1.0f };
+    constexpr wis::ColorClear color2{ 1.0f, 0.2f, 0.4f, 1.0f };
+    std::array rtvsx{
+        std::pair{ rtvs[swap.GetNextIndex()], color },
+        std::pair{ rtvs2[swap.GetNextIndex()], color2 }
+    };
 
-	context.SetGraphicsDescriptorSet(root);
-	context.RSSetViewport({ float(wnd.width()), float(wnd.height()) });
-	context.RSSetScissorRect({ long(wnd.width()), long(wnd.height()) });
-	context.IASetPrimitiveTopology(wis::PrimitiveTopology::trianglelist);
-	context.IASetVertexBuffers({ &vb, 1 });
+    context.SetGraphicsDescriptorSet(root);
+    context.RSSetViewport({ float(wnd.width()), float(wnd.height()) });
+    context.RSSetScissorRect({ long(wnd.width()), long(wnd.height()) });
+    context.IASetPrimitiveTopology(wis::PrimitiveTopology::trianglelist);
+    context.IASetVertexBuffers({ &vb, 1 });
 
-	context.BeginRenderPass(render_pass, { rtvsx.data(), swap.StereoSupported() + 1u });
-	context.DrawInstanced(3);
-	context.EndRenderPass();
+    context.BeginRenderPass(render_pass, { rtvsx.data(), swap.StereoSupported() + 1u });
+    context.DrawInstanced(3);
+    context.EndRenderPass();
 
-	context.TextureBarrier({
-		.state_before = wis::TextureState::RenderTarget,
-		.state_after = wis::TextureState::Present,
-		.access_before = wis::ResourceAccess::RenderTarget,
-		.access_after = wis::ResourceAccess::Common,
-		}, back);
-	context.Close();
-	queue.ExecuteCommandList(context);
+    context.TextureBarrier({
+                                   .state_before = wis::TextureState::RenderTarget,
+                                   .state_after = wis::TextureState::Present,
+                                   .access_before = wis::ResourceAccess::RenderTarget,
+                                   .access_after = wis::ResourceAccess::Common,
+                           },
+                           back);
+    context.Close();
+    queue.ExecuteCommandList(context);
 
-	swap.Present();
+    swap.Present();
 
-	WaitForGPU();
+    WaitForGPU();
 }
-
 
 void App::WaitForGPU()
 {
-	const uint64_t vfence = fence_value;
-	queue.Signal(fence, vfence);
-	fence_value++;
-	fence.Wait(vfence);
+    const uint64_t vfence = fence_value;
+    queue.Signal(fence, vfence);
+    fence_value++;
+    fence.Wait(vfence);
 }

--- a/examples/hello-triangle-modules/entry_main.cpp
+++ b/examples/hello-triangle-modules/entry_main.cpp
@@ -1,5 +1,5 @@
 // Has to be here, since Vulkan has a bug with static function
-#if !defined(WISDOM_WINDOWS) || defined(WISDOM_VULKAN_FOUND) && defined(WISDOM_FORCE_VULKAN) 
+#if !defined(WISDOM_WINDOWS) || defined(WISDOM_VULKAN_FOUND) && defined(WISDOM_FORCE_VULKAN)
 #include <vulkan/vulkan.hpp>
 #endif
 
@@ -7,6 +7,6 @@ import app;
 
 int main()
 {
-	App app(1920, 1080);
-	return app.Start();
+    App app(1920, 1080);
+    return app.Start();
 }

--- a/examples/hello-triangle-modules/window.ixx
+++ b/examples/hello-triangle-modules/window.ixx
@@ -12,7 +12,7 @@ module;
 #include <KDGui/platform/linux/wayland/linux_wayland_platform_integration.h>
 #endif
 #if defined(KD_PLATFORM_MACOS)
-extern CAMetalLayer* createMetalLayer(KDGui::Window* window);
+extern CAMetalLayer *createMetalLayer(KDGui::Window *window);
 #endif
 
 #include <KDGui/window.h>
@@ -24,69 +24,71 @@ import wisdom.api;
 class WindowP;
 export class Window
 {
-	friend class XApp;
+    friend class XApp;
+
 private:
-	Window(uint32_t width, uint32_t height, WindowP* p);
+    Window(uint32_t width, uint32_t height, WindowP *p);
+
 public:
-	~Window();
+    ~Window();
+
 public:
-	bool visible()const noexcept;
-	uint32_t width()const noexcept;
-	uint32_t height()const noexcept;
-	wis::SurfaceParameters GetSurfaceOptions()const noexcept;
+    bool visible() const noexcept;
+    uint32_t width() const noexcept;
+    uint32_t height() const noexcept;
+    wis::SurfaceParameters GetSurfaceOptions() const noexcept;
+
 private:
-	WindowP* p;
+    WindowP *p;
 };
 
 class XAppP;
 export class XApp
 {
 public:
-	XApp();
-	~XApp();
+    XApp();
+    ~XApp();
+
 public:
-	void ProcessEvents();
-	Window createWindow(uint32_t width, uint32_t height);
+    void ProcessEvents();
+    Window createWindow(uint32_t width, uint32_t height);
+
 private:
-	std::unique_ptr<XAppP> p;
+    std::unique_ptr<XAppP> p;
 };
-
-
 
 class WindowP : public KDGui::Window
 {
-
 };
 
-
-Window::Window(uint32_t width, uint32_t height, WindowP* p)
-	: p(p)
+Window::Window(uint32_t width, uint32_t height, WindowP *p)
+    : p(p)
 {
-	p->width = 1920;
-	p->height = 1080;
-	p->visible = true;
+    p->width = 1920;
+    p->height = 1080;
+    p->visible = true;
 }
 Window::~Window()
 {
-	p->destroy();
+    p->destroy();
 }
 
 uint32_t Window::width() const noexcept
 {
-	return p->width.get();
+    return p->width.get();
 }
 uint32_t Window::height() const noexcept
 {
-	return p->height.get();
+    return p->height.get();
 }
 
-wis::SurfaceParameters Window::GetSurfaceOptions()const noexcept
+wis::SurfaceParameters Window::GetSurfaceOptions() const noexcept
 {
 #if defined(KD_PLATFORM_WIN32)
-	auto win32Window = dynamic_cast<KDGui::Win32PlatformWindow*>(p->platformWindow());
-	return wis::SurfaceParameters{
-		win32Window->handle()
-	};
+    auto win32Window = dynamic_cast<KDGui::Win32PlatformWindow *>(p->platformWindow());
+    return wis::SurfaceParameters{
+        win32Window->handle()
+    };
 #elif defined(KD_PLATFORM_LINUX)
     if (KDGui::LinuxWaylandPlatformIntegration::checkAvailable()) {
         auto *platformIntegration = KDGui::GuiApplication::instance()->guiPlatformIntegration();
@@ -104,38 +106,36 @@ wis::SurfaceParameters Window::GetSurfaceOptions()const noexcept
         };
     }
 #elif defined(KD_PLATFORM_MACOS)
-	return wis::SurfaceParameters{
-		.layer = createMetalLayer(this)
-	};
+    return wis::SurfaceParameters{
+        .layer = createMetalLayer(this)
+    };
 #endif
-	return {};
+    return {};
 }
 bool Window::visible() const noexcept
 {
-	return p->visible.get();
+    return p->visible.get();
 }
-
 
 class XAppP
 {
 public:
-	KDGui::GuiApplication app;
+    KDGui::GuiApplication app;
 };
 
 XApp::XApp()
-	:p(new XAppP())
+    : p(new XAppP())
 {
 }
 XApp::~XApp()
 {
 }
 
-
 void XApp::ProcessEvents()
 {
-	p->app.processEvents();
+    p->app.processEvents();
 }
 Window XApp::createWindow(uint32_t width, uint32_t height)
 {
-	return Window(width, height, p->app.createChild<WindowP>());
+    return Window(width, height, p->app.createChild<WindowP>());
 }

--- a/examples/hello-triangle-win32/include/example/app.h
+++ b/examples/hello-triangle-win32/include/example/app.h
@@ -2,46 +2,47 @@
 #include <example/window.h>
 #include <wisdom/wisdom.h>
 
-namespace Test
+namespace Test {
+class App
 {
-	class App
-	{
-	public:
-		App(uint32_t width, uint32_t height);
-		~App()
-		{
-			WaitForGPU();
-		}
-	public:
-		int Start();
-		void Frame();
-		void ProcessEvent(Event e);
-		void OnResize(uint32_t width, uint32_t height);
-		void WaitForGPU();
-	private:
-		Window wnd;
+public:
+    App(uint32_t width, uint32_t height);
+    ~App()
+    {
+        WaitForGPU();
+    }
 
-		std::optional<wis::Factory> factory;
+public:
+    int Start();
+    void Frame();
+    void ProcessEvent(Event e);
+    void OnResize(uint32_t width, uint32_t height);
+    void WaitForGPU();
 
-		wis::Device device;
-		wis::CommandQueue queue;
-		wis::SwapChain swap;
+private:
+    Window wnd;
 
-		wis::CommandList context;
-		wis::Fence fence;
-		wis::ResourceAllocator allocator;
-		
-		wis::Shader vs;
-		wis::Shader ps;
-		
-		wis::RootSignature root;
-		wis::PipelineState pipeline;
-		wis::VertexBufferView vb;
-		wis::RenderTargetView rtvs[2];
-		wis::RenderTargetView rtvs2[2];
-		
-		wis::Buffer vertex_buffer;
-		wis::RenderPass render_pass;
-		uint64_t fence_value = 1;
-	};
-}
+    std::optional<wis::Factory> factory;
+
+    wis::Device device;
+    wis::CommandQueue queue;
+    wis::SwapChain swap;
+
+    wis::CommandList context;
+    wis::Fence fence;
+    wis::ResourceAllocator allocator;
+
+    wis::Shader vs;
+    wis::Shader ps;
+
+    wis::RootSignature root;
+    wis::PipelineState pipeline;
+    wis::VertexBufferView vb;
+    wis::RenderTargetView rtvs[2];
+    wis::RenderTargetView rtvs2[2];
+
+    wis::Buffer vertex_buffer;
+    wis::RenderPass render_pass;
+    uint64_t fence_value = 1;
+};
+} // namespace Test

--- a/examples/hello-triangle-win32/include/example/keyboard.h
+++ b/examples/hello-triangle-win32/include/example/keyboard.h
@@ -5,68 +5,72 @@
 
 class Keyboard
 {
-	friend class Window;
+    friend class Window;
+
 public:
-	class Event
-	{
-	public:
-		enum class Type
-		{
-			Press,
-			Release,
-		};
-	private:
-		Type type;
-		unsigned char code;
-	public:
-		Event(Type type, unsigned char code) noexcept
-			:
-			type(type),
-			code(code)
-		{}
-		bool IsPress() const noexcept
-		{
-			return type == Type::Press;
-		}
-		bool IsRelease() const noexcept
-		{
-			return type == Type::Release;
-		}
-		unsigned char GetCode() const noexcept
-		{
-			return code;
-		}
-	};
+    class Event
+    {
+    public:
+        enum class Type {
+            Press,
+            Release,
+        };
+
+    private:
+        Type type;
+        unsigned char code;
+
+    public:
+        Event(Type type, unsigned char code) noexcept
+            : type(type), code(code)
+        {
+        }
+        bool IsPress() const noexcept
+        {
+            return type == Type::Press;
+        }
+        bool IsRelease() const noexcept
+        {
+            return type == Type::Release;
+        }
+        unsigned char GetCode() const noexcept
+        {
+            return code;
+        }
+    };
+
 public:
-	Keyboard() = default;
-	Keyboard(const Keyboard&) = delete;
-	Keyboard& operator=(const Keyboard&) = delete;
-	// key event stuff
-	bool KeyIsPressed(unsigned char keycode) const noexcept;
-	std::optional<Event> ReadKey() noexcept;
-	bool KeyIsEmpty() const noexcept;
-	void FlushKey() noexcept;
-	// char event stuff
-	std::optional<char> ReadChar() noexcept;
-	bool CharIsEmpty() const noexcept;
-	void FlushChar() noexcept;
-	void Flush() noexcept;
-	// autorepeat control
-	void EnableAutorepeat() noexcept;
-	void DisableAutorepeat() noexcept;
-	bool AutorepeatIsEnabled() const noexcept;
+    Keyboard() = default;
+    Keyboard(const Keyboard &) = delete;
+    Keyboard &operator=(const Keyboard &) = delete;
+    // key event stuff
+    bool KeyIsPressed(unsigned char keycode) const noexcept;
+    std::optional<Event> ReadKey() noexcept;
+    bool KeyIsEmpty() const noexcept;
+    void FlushKey() noexcept;
+    // char event stuff
+    std::optional<char> ReadChar() noexcept;
+    bool CharIsEmpty() const noexcept;
+    void FlushChar() noexcept;
+    void Flush() noexcept;
+    // autorepeat control
+    void EnableAutorepeat() noexcept;
+    void DisableAutorepeat() noexcept;
+    bool AutorepeatIsEnabled() const noexcept;
+
 private:
-	void OnKeyPressed(unsigned char keycode) noexcept;
-	void OnKeyReleased(unsigned char keycode) noexcept;
-	void OnChar(char character) noexcept;
-	void ClearState() noexcept;
-	template<typename T>
-	static void TrimBuffer(std::queue<T>& buffer) noexcept;
+    void OnKeyPressed(unsigned char keycode) noexcept;
+    void OnKeyReleased(unsigned char keycode) noexcept;
+    void OnChar(char character) noexcept;
+    void ClearState() noexcept;
+    template<typename T>
+    static void TrimBuffer(std::queue<T> &buffer) noexcept;
+
 private:
-	static constexpr unsigned int nKeys = 256u;
-	static constexpr unsigned int bufferSize = 16u;
-	bool autorepeatEnabled = false;
-	std::bitset<nKeys> keystates;
-	std::queue<Event> keybuffer;
-	std::queue<char> charbuffer;
+    static constexpr unsigned int nKeys = 256u;
+    static constexpr unsigned int bufferSize = 16u;
+    bool autorepeatEnabled = false;
+    std::bitset<nKeys> keystates;
+    std::queue<Event> keybuffer;
+    std::queue<char> charbuffer;
 };

--- a/examples/hello-triangle-win32/include/example/menu.h
+++ b/examples/hello-triangle-win32/include/example/menu.h
@@ -1,56 +1,56 @@
 #pragma once
 #include <wil/resource.h>
 
-namespace UT
+namespace UT {
+class Menu
 {
-	class Menu
-	{
-	public:
-		enum class Mode
-		{
-			Image,
-			Video,
-			Model,
-			Game
-		};
-	public:
-		Menu() = default;
-	public:
-		void Initialize(HMENU menu)noexcept
-		{
-			main_menu.reset(menu);
-			file.reset(GetSubMenu(menu, 0));
-			view.reset(GetSubMenu(menu, 1));
-			mode.reset(GetSubMenu(menu, 2));
-			styles.reset(GetSubMenu(view.get(), 1));
-		}
-		void EnableLoading()noexcept
-		{
-			EnableMenuItem(file.get(), 0, MF_BYPOSITION | MF_ENABLED);
-		}
-		void DisableLoading()noexcept
-		{
-			EnableMenuItem(file.get(), 0, MF_BYPOSITION | MF_DISABLED);
-		}
-		void ToggleGrid()noexcept
-		{
-			grid_enabled ^= 1;
-			MENUITEMINFO mii
-			{
-				.cbSize = sizeof(MENUITEMINFO),
-				.fMask = MIIM_STATE,
-				.fState = UINT(grid_enabled ? MFS_CHECKED : MFS_UNCHECKED)
-			};
-			SetMenuItemInfo(view.get(), 0, true, &mii);
-		}
-		bool GridEnabled()const noexcept { return grid_enabled; }
-	private:
-		wil::unique_hmenu main_menu;
-		wil::unique_hmenu file;
-		wil::unique_hmenu view;
-		wil::unique_hmenu styles;
-		wil::unique_hmenu mode;
+public:
+    enum class Mode {
+        Image,
+        Video,
+        Model,
+        Game
+    };
 
-		bool grid_enabled = false;
-	};
-}
+public:
+    Menu() = default;
+
+public:
+    void Initialize(HMENU menu) noexcept
+    {
+        main_menu.reset(menu);
+        file.reset(GetSubMenu(menu, 0));
+        view.reset(GetSubMenu(menu, 1));
+        mode.reset(GetSubMenu(menu, 2));
+        styles.reset(GetSubMenu(view.get(), 1));
+    }
+    void EnableLoading() noexcept
+    {
+        EnableMenuItem(file.get(), 0, MF_BYPOSITION | MF_ENABLED);
+    }
+    void DisableLoading() noexcept
+    {
+        EnableMenuItem(file.get(), 0, MF_BYPOSITION | MF_DISABLED);
+    }
+    void ToggleGrid() noexcept
+    {
+        grid_enabled ^= 1;
+        MENUITEMINFO mii{
+            .cbSize = sizeof(MENUITEMINFO),
+            .fMask = MIIM_STATE,
+            .fState = UINT(grid_enabled ? MFS_CHECKED : MFS_UNCHECKED)
+        };
+        SetMenuItemInfo(view.get(), 0, true, &mii);
+    }
+    bool GridEnabled() const noexcept { return grid_enabled; }
+
+private:
+    wil::unique_hmenu main_menu;
+    wil::unique_hmenu file;
+    wil::unique_hmenu view;
+    wil::unique_hmenu styles;
+    wil::unique_hmenu mode;
+
+    bool grid_enabled = false;
+};
+} // namespace UT

--- a/examples/hello-triangle-win32/include/example/mouse.h
+++ b/examples/hello-triangle-win32/include/example/mouse.h
@@ -4,145 +4,145 @@
 
 class Mouse
 {
-	friend class Window;
+    friend class Window;
+
 public:
-	struct RawDelta
-	{
-		int x, y;
-	};
-	class Event
-	{
-	public:
-		enum class Type
-		{
-			LPress,
-			LRelease,
-			RPress,
-			RRelease,
-			WheelUp,
-			WheelDown,
-			Move,
-			Enter,
-			Leave,
-		};
-	private:
-		Type type;
-		bool leftIsPressed;
-		bool rightIsPressed;
-		int x;
-		int y;
-	public:
-		Event(Type type, const Mouse& parent) noexcept
-			:
-			type(type),
-			leftIsPressed(parent.leftIsPressed),
-			rightIsPressed(parent.rightIsPressed),
-			x(parent.x),
-			y(parent.y)
-		{}
-		Type GetType() const noexcept
-		{
-			return type;
-		}
-		std::pair<int, int> GetPos() const noexcept
-		{
-			return{ x,y };
-		}
-		int GetPosX() const noexcept
-		{
-			return x;
-		}
-		int GetPosY() const noexcept
-		{
-			return y;
-		}
-		bool LeftIsPressed() const noexcept
-		{
-			return leftIsPressed;
-		}
-		bool RightIsPressed() const noexcept
-		{
-			return rightIsPressed;
-		}
-	};
+    struct RawDelta {
+        int x, y;
+    };
+    class Event
+    {
+    public:
+        enum class Type {
+            LPress,
+            LRelease,
+            RPress,
+            RRelease,
+            WheelUp,
+            WheelDown,
+            Move,
+            Enter,
+            Leave,
+        };
+
+    private:
+        Type type;
+        bool leftIsPressed;
+        bool rightIsPressed;
+        int x;
+        int y;
+
+    public:
+        Event(Type type, const Mouse &parent) noexcept
+            : type(type), leftIsPressed(parent.leftIsPressed), rightIsPressed(parent.rightIsPressed), x(parent.x), y(parent.y)
+        {
+        }
+        Type GetType() const noexcept
+        {
+            return type;
+        }
+        std::pair<int, int> GetPos() const noexcept
+        {
+            return { x, y };
+        }
+        int GetPosX() const noexcept
+        {
+            return x;
+        }
+        int GetPosY() const noexcept
+        {
+            return y;
+        }
+        bool LeftIsPressed() const noexcept
+        {
+            return leftIsPressed;
+        }
+        bool RightIsPressed() const noexcept
+        {
+            return rightIsPressed;
+        }
+    };
+
 public:
-	Mouse() = default;
-	Mouse(const Mouse&) = delete;
-	Mouse& operator=(const Mouse&) = delete;
-	std::pair<int, int> GetPos() const noexcept
-	{
-		return{ x,y };
-	}
-	std::optional<RawDelta> ReadRawDelta() noexcept;
-	int GetPosX() const noexcept
-	{
-		return x;
-	}
-	int GetPosY() const noexcept
-	{
-		return y;
-	}
-	bool IsInWindow() const noexcept
-	{
-		return isInWindow;
-	}
-	bool LeftIsPressed() const noexcept
-	{
-		return leftIsPressed;
-	}
-	bool RightIsPressed() const noexcept
-	{
-		return rightIsPressed;
-	}
-	std::optional<Mouse::Event> Read() noexcept;
-	bool IsEmpty() const noexcept
-	{
-		return buffer.empty();
-	}
-	void Flush() noexcept
-	{
-		buffer = std::queue<Event>();
-	}
-	void BoundCursor(int width, int height) noexcept
-	{
-		x = std::clamp(x, 0, width - 1);
-		y = std::clamp(y, 0, height - 1);
-	}
-	void EnableRaw() noexcept
-	{
-		rawEnabled = true;
-	}
-	void DisableRaw() noexcept
-	{
-		rawEnabled = false;
-	}
-	bool RawEnabled() const noexcept
-	{
-		return rawEnabled;
-	}
+    Mouse() = default;
+    Mouse(const Mouse &) = delete;
+    Mouse &operator=(const Mouse &) = delete;
+    std::pair<int, int> GetPos() const noexcept
+    {
+        return { x, y };
+    }
+    std::optional<RawDelta> ReadRawDelta() noexcept;
+    int GetPosX() const noexcept
+    {
+        return x;
+    }
+    int GetPosY() const noexcept
+    {
+        return y;
+    }
+    bool IsInWindow() const noexcept
+    {
+        return isInWindow;
+    }
+    bool LeftIsPressed() const noexcept
+    {
+        return leftIsPressed;
+    }
+    bool RightIsPressed() const noexcept
+    {
+        return rightIsPressed;
+    }
+    std::optional<Mouse::Event> Read() noexcept;
+    bool IsEmpty() const noexcept
+    {
+        return buffer.empty();
+    }
+    void Flush() noexcept
+    {
+        buffer = std::queue<Event>();
+    }
+    void BoundCursor(int width, int height) noexcept
+    {
+        x = std::clamp(x, 0, width - 1);
+        y = std::clamp(y, 0, height - 1);
+    }
+    void EnableRaw() noexcept
+    {
+        rawEnabled = true;
+    }
+    void DisableRaw() noexcept
+    {
+        rawEnabled = false;
+    }
+    bool RawEnabled() const noexcept
+    {
+        return rawEnabled;
+    }
+
 private:
-	void OnMouseMove(int x, int y) noexcept;
-	void OnMouseLeave() noexcept;
-	void OnMouseEnter() noexcept;
-	void OnRawDelta(int dx, int dy) noexcept;
-	void OnLeftPressed(int x, int y) noexcept;
-	void OnLeftReleased(int x, int y) noexcept;
-	void OnRightPressed(int x, int y) noexcept;
-	void OnRightReleased(int x, int y) noexcept;
-	void OnWheelUp(int x, int y) noexcept;
-	void OnWheelDown(int x, int y) noexcept;
-	void TrimBuffer() noexcept;
-	void TrimRawInputBuffer() noexcept;
-	void OnWheelDelta(int x, int y, int delta) noexcept;
+    void OnMouseMove(int x, int y) noexcept;
+    void OnMouseLeave() noexcept;
+    void OnMouseEnter() noexcept;
+    void OnRawDelta(int dx, int dy) noexcept;
+    void OnLeftPressed(int x, int y) noexcept;
+    void OnLeftReleased(int x, int y) noexcept;
+    void OnRightPressed(int x, int y) noexcept;
+    void OnRightReleased(int x, int y) noexcept;
+    void OnWheelUp(int x, int y) noexcept;
+    void OnWheelDown(int x, int y) noexcept;
+    void TrimBuffer() noexcept;
+    void TrimRawInputBuffer() noexcept;
+    void OnWheelDelta(int x, int y, int delta) noexcept;
+
 private:
-	static constexpr unsigned int bufferSize = 16u;
-	int x;
-	int y;
-	bool leftIsPressed = false;
-	bool rightIsPressed = false;
-	bool isInWindow = false;
-	int wheelDeltaCarry = 0;
-	bool rawEnabled = false;
-	std::queue<Event> buffer;
-	std::queue<RawDelta> rawDeltaBuffer;
+    static constexpr unsigned int bufferSize = 16u;
+    int x;
+    int y;
+    bool leftIsPressed = false;
+    bool rightIsPressed = false;
+    bool isInWindow = false;
+    int wheelDeltaCarry = 0;
+    bool rawEnabled = false;
+    std::queue<Event> buffer;
+    std::queue<RawDelta> rawDeltaBuffer;
 };

--- a/examples/hello-triangle-win32/include/example/window.h
+++ b/examples/hello-triangle-win32/include/example/window.h
@@ -6,119 +6,132 @@
 #include <array>
 #include <type_traits>
 
-namespace ver
-{
-	class FileOpenDialog;
+namespace ver {
+class FileOpenDialog;
 }
 
-enum class Event : uint8_t
-{
-	Resize,
-	Restyle,
-	LoadAsset,
-	Play,
-	Count
+enum class Event : uint8_t {
+    Resize,
+    Restyle,
+    LoadAsset,
+    Play,
+    Count
 };
-constexpr inline auto operator+(Event e) { return static_cast<std::underlying_type<Event>::type>(e); }
-
-struct EventSet
+constexpr inline auto operator+(Event e)
 {
-	void push(Event e)
-	{
-		if (map[+e])return;
-		horizon[iter++] = e;
-		map.set(+e);
-	}
-	auto begin() { return horizon.begin(); }
-	auto end() { return horizon.begin() + iter; }
-	void clear() { iter = 0; map.reset(); }
-	std::array<Event, +Event::Count> horizon{};
-	std::bitset<+Event::Count> map{}; 
-	uint8_t iter = 0;
+    return static_cast<std::underlying_type<Event>::type>(e);
+}
+
+struct EventSet {
+    void push(Event e)
+    {
+        if (map[+e])
+            return;
+        horizon[iter++] = e;
+        map.set(+e);
+    }
+    auto begin() { return horizon.begin(); }
+    auto end() { return horizon.begin() + iter; }
+    void clear()
+    {
+        iter = 0;
+        map.reset();
+    }
+    std::array<Event, +Event::Count> horizon{};
+    std::bitset<+Event::Count> map{};
+    uint8_t iter = 0;
 };
 
 class Window
 {
-	friend class ver::FileOpenDialog;
+    friend class ver::FileOpenDialog;
+
 public:
-	struct EventQueue
-	{
-	public:
-		EventQueue(EventSet& events):events(events){}
-		~EventQueue(){events.clear();}
-	public:
-		auto begin() { return events.begin(); }
-		auto end() { return events.end(); }
-	private:
-		EventSet& events;
-	};
+    struct EventQueue {
+    public:
+        EventQueue(EventSet &events)
+            : events(events) { }
+        ~EventQueue() { events.clear(); }
+
+    public:
+        auto begin() { return events.begin(); }
+        auto end() { return events.end(); }
+
+    private:
+        EventSet &events;
+    };
+
 private:
-	class WindowClass
-	{
-	public:
-		static const char* GetName()noexcept;
-		static HINSTANCE GetInstance()noexcept;
-	private:
-		WindowClass() noexcept;
-		~WindowClass();
-		WindowClass(const WindowClass&) = delete;
-		WindowClass& operator=(const WindowClass&) = delete;
-		static constexpr const char* wndClassName = "Veritas Direct3D Window";
-		static Window::WindowClass wndClass;
-		HINSTANCE hInst;
-	};
+    class WindowClass
+    {
+    public:
+        static const char *GetName() noexcept;
+        static HINSTANCE GetInstance() noexcept;
+
+    private:
+        WindowClass() noexcept;
+        ~WindowClass();
+        WindowClass(const WindowClass &) = delete;
+        WindowClass &operator=(const WindowClass &) = delete;
+        static constexpr const char *wndClassName = "Veritas Direct3D Window";
+        static Window::WindowClass wndClass;
+        HINSTANCE hInst;
+    };
+
 public:
-	Window(unsigned int width, unsigned int height, const char* name);
-	~Window();
-	Window(const Window&) = delete;
-	Window& operator=(const Window&) = delete;
+    Window(unsigned int width, unsigned int height, const char *name);
+    ~Window();
+    Window(const Window &) = delete;
+    Window &operator=(const Window &) = delete;
+
 public:
-	[[nodiscard]]
-	EventQueue GetEvents()noexcept { return { events }; }
-	void EnableLoading();
+    [[nodiscard]] EventQueue GetEvents() noexcept { return { events }; }
+    void EnableLoading();
 
-	int GetWidth() const noexcept { return width; }
-	int GetHeight() const noexcept { return height; }
+    int GetWidth() const noexcept { return width; }
+    int GetHeight() const noexcept { return height; }
 
-	bool DrawGrid()const noexcept { return menu.GridEnabled(); }
+    bool DrawGrid() const noexcept { return menu.GridEnabled(); }
 
-	void EnableCursor() noexcept;
-	void HideCursor() noexcept;
-	void ShowCursor() noexcept;
-	void DisableCursor() noexcept;
-	bool CursorEnabled() const noexcept;
-	bool IsActive()const noexcept{return bActive;}
-	void SetTitle(std::string_view title);
-	void ChangeToFullScreen();
+    void EnableCursor() noexcept;
+    void HideCursor() noexcept;
+    void ShowCursor() noexcept;
+    void DisableCursor() noexcept;
+    bool CursorEnabled() const noexcept;
+    bool IsActive() const noexcept { return bActive; }
+    void SetTitle(std::string_view title);
+    void ChangeToFullScreen();
 
-	HWND GetHandle()const noexcept { return hWnd.get(); }
+    HWND GetHandle() const noexcept { return hWnd.get(); }
 
-	std::optional<WPARAM> ProcessMessages()const noexcept;
+    std::optional<WPARAM> ProcessMessages() const noexcept;
+
 private:
-	static LRESULT WINAPI HandleMsgSetup(HWND hWnd, UINT msg, WPARAM wParam, LPARAM lParam);
-	static LRESULT WINAPI HandleMsgThunk(HWND hWnd, UINT msg, WPARAM wParam, LPARAM lParam);
-	LRESULT HandleMsg(HWND hWnd, UINT msg, WPARAM wParam, LPARAM lParam);
+    static LRESULT WINAPI HandleMsgSetup(HWND hWnd, UINT msg, WPARAM wParam, LPARAM lParam);
+    static LRESULT WINAPI HandleMsgThunk(HWND hWnd, UINT msg, WPARAM wParam, LPARAM lParam);
+    LRESULT HandleMsg(HWND hWnd, UINT msg, WPARAM wParam, LPARAM lParam);
 
-	void ConfineCursor() noexcept;
-	void FreeCursor() noexcept;
-	void EnableImGuiMouse() noexcept;
-	void DisableImGuiMouse() noexcept;
-	void ShowImGuiMouse()noexcept;
+    void ConfineCursor() noexcept;
+    void FreeCursor() noexcept;
+    void EnableImGuiMouse() noexcept;
+    void DisableImGuiMouse() noexcept;
+    void ShowImGuiMouse() noexcept;
+
 public:
-	Keyboard kbd;
-	Mouse mouse;
-private:
-	bool cursorEnabled = true;
-	bool cursorShown = false;
-	bool cursorActive = false;
-	bool bActive = true;
-	int width;
-	int height;
-	wil::unique_hwnd hWnd;
-	UT::Menu menu;
-	wil::unique_haccel Accelerator;
+    Keyboard kbd;
+    Mouse mouse;
 
-	std::vector<BYTE> rawBuffer;
-	EventSet events;
+private:
+    bool cursorEnabled = true;
+    bool cursorShown = false;
+    bool cursorActive = false;
+    bool bActive = true;
+    int width;
+    int height;
+    wil::unique_hwnd hWnd;
+    UT::Menu menu;
+    wil::unique_haccel Accelerator;
+
+    std::vector<BYTE> rawBuffer;
+    EventSet events;
 };
-

--- a/examples/hello-triangle-win32/src/app.cpp
+++ b/examples/hello-triangle-win32/src/app.cpp
@@ -4,232 +4,214 @@
 #include <fstream>
 #include <DirectXMath.h>
 
-
-struct LogProvider : public wis::LogLayer
-{
-	virtual void Log(wis::Severity sev, std::string message, wis::source_location sl = wis::source_location::current())override
-	{
-		std::cout << wis::format("[{}]: {}\n", wis::severity_strings[+sev], message);
-	};
+struct LogProvider : public wis::LogLayer {
+    virtual void Log(wis::Severity sev, std::string message, wis::source_location sl = wis::source_location::current()) override
+    {
+        std::cout << wis::format("[{}]: {}\n", wis::severity_strings[+sev], message);
+    };
 };
 
 constexpr wis::ApplicationInfo app_info{
-	.application_name = "example",
-		.engine_name = "none",
+    .application_name = "example",
+    .engine_name = "none",
 };
 
 // not WinRT Compatible
 template<class ShaderTy>
 auto LoadShader(std::filesystem::path p)
 {
-	if constexpr (ShaderTy::language == wis::ShaderLang::dxil)
-		p+=u".cso";
-	else if constexpr (ShaderTy::language == wis::ShaderLang::spirv)
-		p+=u".spv";
+    if constexpr (ShaderTy::language == wis::ShaderLang::dxil)
+        p += u".cso";
+    else if constexpr (ShaderTy::language == wis::ShaderLang::spirv)
+        p += u".spv";
 
-	std::ifstream t{p, std::ios::binary};
-	t.seekg(0, std::ios::end);
-	size_t size = t.tellg();
-	wis::shared_blob ret{size};
-	t.seekg(0);
-	t.read(ret.data<char>(), size);
-	return ret;
+    std::ifstream t{ p, std::ios::binary };
+    t.seekg(0, std::ios::end);
+    size_t size = t.tellg();
+    wis::shared_blob ret{ size };
+    t.seekg(0);
+    t.read(ret.data<char>(), size);
+    return ret;
 }
 
 template<class T>
-std::span<std::byte> RawView(T& data)
+std::span<std::byte> RawView(T &data)
 {
-	return { (std::byte*)&data, sizeof(T) };
+    return { (std::byte *)&data, sizeof(T) };
 }
 
 Test::App::App(uint32_t width, uint32_t height)
-	:wnd(width, height, "VTest")
+    : wnd(width, height, "VTest")
 {
-	wis::LibLogger::SetLogLayer(std::make_shared<LogProvider>());
+    wis::LibLogger::SetLogLayer(std::make_shared<LogProvider>());
 
-	factory.emplace(app_info);
+    factory.emplace(app_info);
 
-	for (auto&& a : factory->EnumerateAdapters(wis::AdapterPreference::Performance))
-	{
-		auto desc = a.GetDesc();
+    for (auto &&a : factory->EnumerateAdapters(wis::AdapterPreference::Performance)) {
+        auto desc = a.GetDesc();
 
-		if (desc.IsSoftware())
-			wis::lib_warn("Loading WARP adapter");
+        if (desc.IsSoftware())
+            wis::lib_warn("Loading WARP adapter");
 
-		std::cout << desc.to_string();
+        std::cout << desc.to_string();
 
-		if (device.Initialize(a))
-		{ 
-			allocator = wis::ResourceAllocator{ device, a };
-			break;
-		}
-	}
-	
-	queue = device.CreateCommandQueue();
+        if (device.Initialize(a)) {
+            allocator = wis::ResourceAllocator{ device, a };
+            break;
+        }
+    }
 
-	swap = device.CreateSwapchain(queue, wis::SwapchainOptions{
-			uint32_t(wnd.GetWidth()),
-			uint32_t(wnd.GetHeight()),
-			wis::SwapchainOptions::default_frames,
-			wis::SwapchainOptions::default_format,
-			true
-		},
-		wis::SurfaceParameters{
-		wnd.GetHandle()
-	});
+    queue = device.CreateCommandQueue();
 
-	fence = device.CreateFence();
-	context = device.CreateCommandList(wis::QueueType::direct);
-	vs = device.CreateShader(LoadShader<wis::Shader>(SHADER_DIR "/example.vs"), wis::ShaderType::vertex);
-	ps = device.CreateShader(LoadShader<wis::Shader>(SHADER_DIR "/example.ps"), wis::ShaderType::pixel);
-	root = device.CreateRootSignature();//empty
+    swap = device.CreateSwapchain(queue, wis::SwapchainOptions{ uint32_t(wnd.GetWidth()), uint32_t(wnd.GetHeight()), wis::SwapchainOptions::default_frames, wis::SwapchainOptions::default_format, true },
+                                  wis::SurfaceParameters{
+                                          wnd.GetHandle() });
 
-	OnResize(width, height);
+    fence = device.CreateFence();
+    context = device.CreateCommandList(wis::QueueType::direct);
+    vs = device.CreateShader(LoadShader<wis::Shader>(SHADER_DIR "/example.vs"), wis::ShaderType::vertex);
+    ps = device.CreateShader(LoadShader<wis::Shader>(SHADER_DIR "/example.ps"), wis::ShaderType::pixel);
+    root = device.CreateRootSignature(); // empty
 
-	struct Vertex
-	{
-		DirectX::XMFLOAT3 pos;
-		DirectX::XMFLOAT4 col;
-	};
-	auto aspect_ratio = float(width) / float(height);
-	Vertex triangleVertices[] =
-	{
-		{ { 0.0f, 0.25f * aspect_ratio , 0.0f }, { 1.0f, 0.0f, 0.0f, 1.0f } },
-		{ { 0.25f, -0.25f * aspect_ratio , 0.0f }, { 0.0f, 1.0f, 0.0f, 1.0f } },
-		{ { -0.25f, -0.25f * aspect_ratio , 0.0f }, { 0.0f, 0.0f, 1.0f, 1.0f } }
-	};
-	
-	vertex_buffer = allocator.CreatePersistentBuffer(sizeof(triangleVertices), wis::BufferFlags::VertexBuffer);
+    OnResize(width, height);
 
-	auto upl_vbuf = allocator.CreateUploadBuffer(sizeof(triangleVertices));
-	upl_vbuf.UpdateSubresource(RawView(triangleVertices));
-	
-	context.Reset();
-	context.CopyBuffer(upl_vbuf, vertex_buffer, sizeof(triangleVertices));
-	context.BufferBarrier({
-		.access_before = wis::ResourceAccess::CopyDest,
-		.access_after = wis::ResourceAccess::VertexBuffer
-	}, vertex_buffer);
-	context.Close();
-	
-	queue.ExecuteCommandList(context);
-	WaitForGPU();
-	
-	vb = vertex_buffer.GetVertexBufferView(sizeof(Vertex));
+    struct Vertex {
+        DirectX::XMFLOAT3 pos;
+        DirectX::XMFLOAT4 col;
+    };
+    auto aspect_ratio = float(width) / float(height);
+    Vertex triangleVertices[] = {
+        { { 0.0f, 0.25f * aspect_ratio, 0.0f }, { 1.0f, 0.0f, 0.0f, 1.0f } },
+        { { 0.25f, -0.25f * aspect_ratio, 0.0f }, { 0.0f, 1.0f, 0.0f, 1.0f } },
+        { { -0.25f, -0.25f * aspect_ratio, 0.0f }, { 0.0f, 0.0f, 1.0f, 1.0f } }
+    };
+
+    vertex_buffer = allocator.CreatePersistentBuffer(sizeof(triangleVertices), wis::BufferFlags::VertexBuffer);
+
+    auto upl_vbuf = allocator.CreateUploadBuffer(sizeof(triangleVertices));
+    upl_vbuf.UpdateSubresource(RawView(triangleVertices));
+
+    context.Reset();
+    context.CopyBuffer(upl_vbuf, vertex_buffer, sizeof(triangleVertices));
+    context.BufferBarrier({ .access_before = wis::ResourceAccess::CopyDest,
+                            .access_after = wis::ResourceAccess::VertexBuffer },
+                          vertex_buffer);
+    context.Close();
+
+    queue.ExecuteCommandList(context);
+    WaitForGPU();
+
+    vb = vertex_buffer.GetVertexBufferView(sizeof(Vertex));
 }
 
 int Test::App::Start()
 {
-	while (true)
-	{
-		if (const auto a = wnd.ProcessMessages())
-			return (int)a.value();
+    while (true) {
+        if (const auto a = wnd.ProcessMessages())
+            return (int)a.value();
 
-		for(auto e: wnd.GetEvents())
-			ProcessEvent(e);
-		
-		Frame();
-	}
+        for (auto e : wnd.GetEvents())
+            ProcessEvent(e);
+
+        Frame();
+    }
 }
 
 void Test::App::Frame()
 {
-	context.Reset();
-	auto back = swap.GetBackBuffer();
-	
-	context.TextureBarrier({
-		.state_before = wis::TextureState::Present,
-		.state_after = wis::TextureState::RenderTarget,
-		.access_before = wis::ResourceAccess::Common,
-		.access_after = wis::ResourceAccess::RenderTarget,
-	}, back);
+    context.Reset();
+    auto back = swap.GetBackBuffer();
 
-	constexpr wis::ColorClear color{0.0f, 0.2f, 0.4f, 1.0f};
-	constexpr wis::ColorClear color2{1.0f, 0.2f, 0.4f, 1.0f};
-	std::array rtvsx{
-		std::pair{rtvs[swap.GetNextIndex()], color},
-		std::pair{rtvs2[swap.GetNextIndex()], color2}
-	};
-	
-	context.SetGraphicsDescriptorSet(root);
-	context.RSSetViewport({ float(wnd.GetWidth()),float(wnd.GetHeight()) });
-	context.RSSetScissorRect({ wnd.GetWidth(), wnd.GetHeight() });
-	context.IASetPrimitiveTopology(wis::PrimitiveTopology::trianglelist);
-	context.IASetVertexBuffers({ &vb, 1 });
-	
-	context.BeginRenderPass(render_pass, { rtvsx.data(), swap.StereoSupported() + 1u });
-	context.DrawInstanced(3);
-	context.EndRenderPass();
+    context.TextureBarrier({
+                                   .state_before = wis::TextureState::Present,
+                                   .state_after = wis::TextureState::RenderTarget,
+                                   .access_before = wis::ResourceAccess::Common,
+                                   .access_after = wis::ResourceAccess::RenderTarget,
+                           },
+                           back);
 
-	context.TextureBarrier({
-		.state_before = wis::TextureState::RenderTarget,
-		.state_after = wis::TextureState::Present,
-		.access_before = wis::ResourceAccess::RenderTarget,
-		.access_after = wis::ResourceAccess::Common,
-	}, back);
-	context.Close();
-	queue.ExecuteCommandList(context);
+    constexpr wis::ColorClear color{ 0.0f, 0.2f, 0.4f, 1.0f };
+    constexpr wis::ColorClear color2{ 1.0f, 0.2f, 0.4f, 1.0f };
+    std::array rtvsx{
+        std::pair{ rtvs[swap.GetNextIndex()], color },
+        std::pair{ rtvs2[swap.GetNextIndex()], color2 }
+    };
 
-	swap.Present();
+    context.SetGraphicsDescriptorSet(root);
+    context.RSSetViewport({ float(wnd.GetWidth()), float(wnd.GetHeight()) });
+    context.RSSetScissorRect({ wnd.GetWidth(), wnd.GetHeight() });
+    context.IASetPrimitiveTopology(wis::PrimitiveTopology::trianglelist);
+    context.IASetVertexBuffers({ &vb, 1 });
 
-	WaitForGPU();
+    context.BeginRenderPass(render_pass, { rtvsx.data(), swap.StereoSupported() + 1u });
+    context.DrawInstanced(3);
+    context.EndRenderPass();
+
+    context.TextureBarrier({
+                                   .state_before = wis::TextureState::RenderTarget,
+                                   .state_after = wis::TextureState::Present,
+                                   .access_before = wis::ResourceAccess::RenderTarget,
+                                   .access_after = wis::ResourceAccess::Common,
+                           },
+                           back);
+    context.Close();
+    queue.ExecuteCommandList(context);
+
+    swap.Present();
+
+    WaitForGPU();
 }
 
 void Test::App::ProcessEvent(Event e)
 {
-	switch (e)
-	{
-	case Event::Resize:
-		return OnResize(wnd.GetWidth(), wnd.GetHeight());
-	}
+    switch (e) {
+    case Event::Resize:
+        return OnResize(wnd.GetWidth(), wnd.GetHeight());
+    }
 }
 
 void Test::App::OnResize(uint32_t width, uint32_t height)
 {
-	if(!swap.Resize(width, height))
-		return;
+    if (!swap.Resize(width, height))
+        return;
 
+    std::array cas2{
+        wis::ColorAttachment{
+                .format = wis::SwapchainOptions::default_format,
+                .load = wis::PassLoadOperation::clear },
+        wis::ColorAttachment{
+                .format = wis::SwapchainOptions::default_format,
+                .load = wis::PassLoadOperation::clear }
+    };
 
-	std::array cas2{
-		wis::ColorAttachment {
-			.format = wis::SwapchainOptions::default_format,
-				.load = wis::PassLoadOperation::clear
-		},
-		wis::ColorAttachment {
-			.format = wis::SwapchainOptions::default_format,
-				.load = wis::PassLoadOperation::clear
-		}
-	};
+    // needs to be recreated for vulkan for now
+    render_pass = device.CreateRenderPass({ width, height }, { cas2.data(), swap.StereoSupported() + 1u });
 
-	// needs to be recreated for vulkan for now
-	render_pass = device.CreateRenderPass({ width, height }, { cas2.data(), swap.StereoSupported() + 1u });
+    // needs to be recreated for vulkan for now
+    static constexpr std::array<wis::InputLayoutDesc, 2> ia{
+        wis::InputLayoutDesc{ 0, "POSITION", 0, wis::DataFormat::r32g32b32_float, 0, 0, wis::InputClassification::vertex, 0 },
+        wis::InputLayoutDesc{ 1, "COLOR", 0, wis::DataFormat::r32g32b32a32_float, 0, 12, wis::InputClassification::vertex, 0 }
+    };
 
-	// needs to be recreated for vulkan for now
-	static constexpr std::array<wis::InputLayoutDesc, 2> ia{
-		wis::InputLayoutDesc{ 0, "POSITION", 0, wis::DataFormat::r32g32b32_float, 0, 0, wis::InputClassification::vertex, 0 },
-		wis::InputLayoutDesc{ 1, "COLOR", 0, wis::DataFormat::r32g32b32a32_float, 0, 12, wis::InputClassification::vertex, 0 }
-	};
+    wis::GraphicsPipelineDesc desc{ root };
+    desc.SetVS(vs);
+    desc.SetPS(ps);
+    desc.SetRenderPass(render_pass);
+    pipeline = device.CreateGraphicsPipeline(std::move(desc), ia);
+    context.SetPipeline(pipeline);
 
-	wis::GraphicsPipelineDesc desc{ root };
-	desc.SetVS(vs);
-	desc.SetPS(ps);
-	desc.SetRenderPass(render_pass);
-	pipeline = device.CreateGraphicsPipeline(std::move(desc), ia);
-	context.SetPipeline(pipeline);
-
-	auto x = swap.GetRenderTargets();
-	for (size_t i = 0; i < x.size(); i++)
-	{
-		rtvs[i] = device.CreateRenderTargetView(x[i]);
-		if (swap.StereoSupported())
-			rtvs2[i] = device.CreateRenderTargetView(x[i], { .base_layer = 1 });
-	}
+    auto x = swap.GetRenderTargets();
+    for (size_t i = 0; i < x.size(); i++) {
+        rtvs[i] = device.CreateRenderTargetView(x[i]);
+        if (swap.StereoSupported())
+            rtvs2[i] = device.CreateRenderTargetView(x[i], { .base_layer = 1 });
+    }
 }
 
 void Test::App::WaitForGPU()
 {
-	const uint64_t vfence = fence_value;
-	queue.Signal(fence, vfence);
-	fence_value++;
-	fence.Wait(vfence);
+    const uint64_t vfence = fence_value;
+    queue.Signal(fence, vfence);
+    fence_value++;
+    fence.Wait(vfence);
 }

--- a/examples/hello-triangle-win32/src/entry_main.cpp
+++ b/examples/hello-triangle-win32/src/entry_main.cpp
@@ -2,6 +2,6 @@
 
 int main()
 {
-	Test::App a{1920, 1080};
-	return a.Start();
+    Test::App a{ 1920, 1080 };
+    return a.Start();
 }

--- a/examples/hello-triangle-win32/src/keyboard.cpp
+++ b/examples/hello-triangle-win32/src/keyboard.cpp
@@ -2,103 +2,99 @@
 
 bool Keyboard::KeyIsPressed(unsigned char keycode) const noexcept
 {
-	return keystates[keycode];
+    return keystates[keycode];
 }
 
 std::optional<Keyboard::Event> Keyboard::ReadKey() noexcept
 {
-	if (keybuffer.size() > 0u)
-	{
-		Keyboard::Event e = keybuffer.front();
-		keybuffer.pop();
-		return e;
-	}
-	return{};
+    if (keybuffer.size() > 0u) {
+        Keyboard::Event e = keybuffer.front();
+        keybuffer.pop();
+        return e;
+    }
+    return {};
 }
 
 bool Keyboard::KeyIsEmpty() const noexcept
 {
-	return keybuffer.empty();
+    return keybuffer.empty();
 }
 
 std::optional<char> Keyboard::ReadChar() noexcept
 {
-	if (charbuffer.size() > 0u)
-	{
-		unsigned char charcode = charbuffer.front();
-		charbuffer.pop();
-		return charcode;
-	}
-	return{};
+    if (charbuffer.size() > 0u) {
+        unsigned char charcode = charbuffer.front();
+        charbuffer.pop();
+        return charcode;
+    }
+    return {};
 }
 
 bool Keyboard::CharIsEmpty() const noexcept
 {
-	return charbuffer.empty();
+    return charbuffer.empty();
 }
 
 void Keyboard::FlushKey() noexcept
 {
-	keybuffer = std::queue<Event>();
+    keybuffer = std::queue<Event>();
 }
 
 void Keyboard::FlushChar() noexcept
 {
-	charbuffer = std::queue<char>();
+    charbuffer = std::queue<char>();
 }
 
 void Keyboard::Flush() noexcept
 {
-	FlushKey();
-	FlushChar();
+    FlushKey();
+    FlushChar();
 }
 
 void Keyboard::EnableAutorepeat() noexcept
 {
-	autorepeatEnabled = true;
+    autorepeatEnabled = true;
 }
 
 void Keyboard::DisableAutorepeat() noexcept
 {
-	autorepeatEnabled = false;
+    autorepeatEnabled = false;
 }
 
 bool Keyboard::AutorepeatIsEnabled() const noexcept
 {
-	return autorepeatEnabled;
+    return autorepeatEnabled;
 }
 
 void Keyboard::OnKeyPressed(unsigned char keycode) noexcept
 {
-	keystates[keycode] = true;
-	keybuffer.push(Keyboard::Event(Keyboard::Event::Type::Press, keycode));
-	TrimBuffer(keybuffer);
+    keystates[keycode] = true;
+    keybuffer.push(Keyboard::Event(Keyboard::Event::Type::Press, keycode));
+    TrimBuffer(keybuffer);
 }
 
 void Keyboard::OnKeyReleased(unsigned char keycode) noexcept
 {
-	keystates[keycode] = false;
-	keybuffer.push(Keyboard::Event(Keyboard::Event::Type::Release, keycode));
-	TrimBuffer(keybuffer);
+    keystates[keycode] = false;
+    keybuffer.push(Keyboard::Event(Keyboard::Event::Type::Release, keycode));
+    TrimBuffer(keybuffer);
 }
 
 void Keyboard::OnChar(char character) noexcept
 {
-	charbuffer.push(character);
-	TrimBuffer(charbuffer);
+    charbuffer.push(character);
+    TrimBuffer(charbuffer);
 }
 
 void Keyboard::ClearState() noexcept
 {
-	keystates.reset();
+    keystates.reset();
 }
 
 template<typename T>
-void Keyboard::TrimBuffer(std::queue<T>& buffer) noexcept
+void Keyboard::TrimBuffer(std::queue<T> &buffer) noexcept
 {
-	while (buffer.size() > bufferSize)
-	{
-		buffer.pop();
-	}
+    while (buffer.size() > bufferSize) {
+        buffer.pop();
+    }
 }
-

--- a/examples/hello-triangle-win32/src/mouse.cpp
+++ b/examples/hello-triangle-win32/src/mouse.cpp
@@ -1,129 +1,122 @@
 #include <example/mouse.h>
 
-
 std::optional<Mouse::RawDelta> Mouse::ReadRawDelta() noexcept
 {
-	if (rawDeltaBuffer.empty())
-	{
-		return{};
-	}
-	const RawDelta d = rawDeltaBuffer.front();
-	rawDeltaBuffer.pop();
-	return d;
+    if (rawDeltaBuffer.empty()) {
+        return {};
+    }
+    const RawDelta d = rawDeltaBuffer.front();
+    rawDeltaBuffer.pop();
+    return d;
 }
 
 std::optional<Mouse::Event> Mouse::Read() noexcept
 {
-	if (buffer.size() > 0u)
-	{
-		Mouse::Event e = buffer.front();
-		buffer.pop();
-		return e;
-	}
-	return{};
+    if (buffer.size() > 0u) {
+        Mouse::Event e = buffer.front();
+        buffer.pop();
+        return e;
+    }
+    return {};
 }
 
 void Mouse::OnMouseMove(int newx, int newy) noexcept
 {
-	x = newx;
-	y = newy;
+    x = newx;
+    y = newy;
 
-	buffer.push(Mouse::Event(Mouse::Event::Type::Move, *this));
-	TrimBuffer();
+    buffer.push(Mouse::Event(Mouse::Event::Type::Move, *this));
+    TrimBuffer();
 }
 
 void Mouse::OnMouseLeave() noexcept
 {
-	isInWindow = false;
-	buffer.push(Mouse::Event(Mouse::Event::Type::Leave, *this));
-	TrimBuffer();
+    isInWindow = false;
+    buffer.push(Mouse::Event(Mouse::Event::Type::Leave, *this));
+    TrimBuffer();
 }
 
 void Mouse::OnMouseEnter() noexcept
 {
-	isInWindow = true;
-	buffer.push(Mouse::Event(Mouse::Event::Type::Enter, *this));
-	TrimBuffer();
+    isInWindow = true;
+    buffer.push(Mouse::Event(Mouse::Event::Type::Enter, *this));
+    TrimBuffer();
 }
 
 void Mouse::OnRawDelta(int dx, int dy) noexcept
 {
-	rawDeltaBuffer.push({ dx,dy });
-	TrimBuffer();
+    rawDeltaBuffer.push({ dx, dy });
+    TrimBuffer();
 }
 
 void Mouse::OnLeftPressed(int x, int y) noexcept
 {
-	leftIsPressed = true;
+    leftIsPressed = true;
 
-	buffer.push(Mouse::Event(Mouse::Event::Type::LPress, *this));
-	TrimBuffer();
+    buffer.push(Mouse::Event(Mouse::Event::Type::LPress, *this));
+    TrimBuffer();
 }
 
 void Mouse::OnLeftReleased(int x, int y) noexcept
 {
-	leftIsPressed = false;
+    leftIsPressed = false;
 
-	buffer.push(Mouse::Event(Mouse::Event::Type::LRelease, *this));
-	TrimBuffer();
+    buffer.push(Mouse::Event(Mouse::Event::Type::LRelease, *this));
+    TrimBuffer();
 }
 
 void Mouse::OnRightPressed(int x, int y) noexcept
 {
-	rightIsPressed = true;
+    rightIsPressed = true;
 
-	buffer.push(Mouse::Event(Mouse::Event::Type::RPress, *this));
-	TrimBuffer();
+    buffer.push(Mouse::Event(Mouse::Event::Type::RPress, *this));
+    TrimBuffer();
 }
 
 void Mouse::OnRightReleased(int x, int y) noexcept
 {
-	rightIsPressed = false;
+    rightIsPressed = false;
 
-	buffer.push(Mouse::Event(Mouse::Event::Type::RRelease, *this));
-	TrimBuffer();
+    buffer.push(Mouse::Event(Mouse::Event::Type::RRelease, *this));
+    TrimBuffer();
 }
 
 void Mouse::OnWheelUp(int x, int y) noexcept
 {
-	buffer.push(Mouse::Event(Mouse::Event::Type::WheelUp, *this));
-	TrimBuffer();
+    buffer.push(Mouse::Event(Mouse::Event::Type::WheelUp, *this));
+    TrimBuffer();
 }
 
 void Mouse::OnWheelDown(int x, int y) noexcept
 {
-	buffer.push(Mouse::Event(Mouse::Event::Type::WheelDown, *this));
-	TrimBuffer();
+    buffer.push(Mouse::Event(Mouse::Event::Type::WheelDown, *this));
+    TrimBuffer();
 }
 
 void Mouse::TrimBuffer() noexcept
 {
-	while (buffer.size() > bufferSize)
-	{
-		buffer.pop();
-	}
+    while (buffer.size() > bufferSize) {
+        buffer.pop();
+    }
 }
 
 void Mouse::TrimRawInputBuffer() noexcept
 {
-	while (rawDeltaBuffer.size() > bufferSize)
-	{
-		rawDeltaBuffer.pop();
-	}
+    while (rawDeltaBuffer.size() > bufferSize) {
+        rawDeltaBuffer.pop();
+    }
 }
 
 void Mouse::OnWheelDelta(int x, int y, int delta) noexcept
 {
-	wheelDeltaCarry += delta;
-	// generate events for every 120 
-	while (wheelDeltaCarry >= 120)
-	{
-		wheelDeltaCarry -= 120;
-		OnWheelUp(x, y);
-	}
-	while (wheelDeltaCarry <= -120)
-	{
-		wheelDeltaCarry += 120;
-		OnWheelDown(x, y);
-	}
+    wheelDeltaCarry += delta;
+    // generate events for every 120
+    while (wheelDeltaCarry >= 120) {
+        wheelDeltaCarry -= 120;
+        OnWheelUp(x, y);
+    }
+    while (wheelDeltaCarry <= -120) {
+        wheelDeltaCarry += 120;
+        OnWheelDown(x, y);
+    }
 }

--- a/examples/hello-triangle-win32/src/window.cpp
+++ b/examples/hello-triangle-win32/src/window.cpp
@@ -3,532 +3,496 @@
 #include <resource.h>
 #include <wisdom/dx12/dx12_checks.h>
 
-//extern IMGUI_IMPL_API LRESULT ImGui_ImplWin32_WndProcHandler(HWND hWnd, UINT msg, WPARAM wParam, LPARAM lParam);
+// extern IMGUI_IMPL_API LRESULT ImGui_ImplWin32_WndProcHandler(HWND hWnd, UINT msg, WPARAM wParam, LPARAM lParam);
 
-enum class MenuItems :UINT_PTR
-{
-	Load = ID_FILE_LOADMODEL,
-	Exit = ID_FILE_EXIT,
-	ShowGrid = ID_OPTIONS_DRAWGRID,
-	Style_VGUI = ID_STYLES_VGUI,
-	Style_Dark = ID_STYLES_DARK,
-	Style_Cherry = ID_STYLES_CHERRY,
-	PlayGame = ID_MODE_GAME,
-	About = ID_HELP_ABOUT,
+enum class MenuItems : UINT_PTR {
+    Load = ID_FILE_LOADMODEL,
+    Exit = ID_FILE_EXIT,
+    ShowGrid = ID_OPTIONS_DRAWGRID,
+    Style_VGUI = ID_STYLES_VGUI,
+    Style_Dark = ID_STYLES_DARK,
+    Style_Cherry = ID_STYLES_CHERRY,
+    PlayGame = ID_MODE_GAME,
+    About = ID_HELP_ABOUT,
 };
 
 INT_PTR CALLBACK About(HWND hDlg, UINT message, WPARAM wParam, LPARAM lParam)
 {
-	UNREFERENCED_PARAMETER(lParam);
-	switch (message)
-	{
-	case WM_INITDIALOG:
-		return (INT_PTR)TRUE;
+    UNREFERENCED_PARAMETER(lParam);
+    switch (message) {
+    case WM_INITDIALOG:
+        return (INT_PTR)TRUE;
 
-	case WM_COMMAND:
-		if (LOWORD(wParam) == IDOK || LOWORD(wParam) == IDCANCEL)
-		{
-			EndDialog(hDlg, LOWORD(wParam));
-			return (INT_PTR)TRUE;
-		}
-		break;
-	}
-	return (INT_PTR)FALSE;
+    case WM_COMMAND:
+        if (LOWORD(wParam) == IDOK || LOWORD(wParam) == IDCANCEL) {
+            EndDialog(hDlg, LOWORD(wParam));
+            return (INT_PTR)TRUE;
+        }
+        break;
+    }
+    return (INT_PTR)FALSE;
 }
 
 Window::WindowClass Window::WindowClass::wndClass;
 
 Window::WindowClass::WindowClass() noexcept
-	:hInst(GetModuleHandle(nullptr))
+    : hInst(GetModuleHandle(nullptr))
 {
-	WNDCLASSEXA wcWindow = { 0 };
-	wcWindow.cbSize = sizeof(wcWindow);
-	wcWindow.style = CS_OWNDC;
-	wcWindow.lpfnWndProc = HandleMsgSetup;
-	wcWindow.cbClsExtra = 0;
-	wcWindow.cbWndExtra = 0;
-	wcWindow.hInstance = GetInstance();
-	wcWindow.hCursor = LoadCursor(NULL, IDC_ARROW);
-	wcWindow.hIcon = LoadIcon(wcWindow.hInstance, MAKEINTRESOURCE(IDI_ICON1));
-	wcWindow.hbrBackground = nullptr;
-	wcWindow.lpszMenuName = MAKEINTRESOURCEA(IDR_MENU1);
-	wcWindow.hIconSm = nullptr;
-	wcWindow.lpszClassName = GetName();
-	RegisterClassExA(&wcWindow);
+    WNDCLASSEXA wcWindow = { 0 };
+    wcWindow.cbSize = sizeof(wcWindow);
+    wcWindow.style = CS_OWNDC;
+    wcWindow.lpfnWndProc = HandleMsgSetup;
+    wcWindow.cbClsExtra = 0;
+    wcWindow.cbWndExtra = 0;
+    wcWindow.hInstance = GetInstance();
+    wcWindow.hCursor = LoadCursor(NULL, IDC_ARROW);
+    wcWindow.hIcon = LoadIcon(wcWindow.hInstance, MAKEINTRESOURCE(IDI_ICON1));
+    wcWindow.hbrBackground = nullptr;
+    wcWindow.lpszMenuName = MAKEINTRESOURCEA(IDR_MENU1);
+    wcWindow.hIconSm = nullptr;
+    wcWindow.lpszClassName = GetName();
+    RegisterClassExA(&wcWindow);
 }
 Window::WindowClass::~WindowClass()
 {
-	UnregisterClassA(wndClassName, GetInstance());
+    UnregisterClassA(wndClassName, GetInstance());
 }
-const char* Window::WindowClass::GetName() noexcept
+const char *Window::WindowClass::GetName() noexcept
 {
-	return wndClassName;
+    return wndClassName;
 }
 HINSTANCE Window::WindowClass::GetInstance() noexcept
 {
-	return wndClass.hInst;
+    return wndClass.hInst;
 }
 
 // Window namespace
-Window::Window(unsigned int width, unsigned int height, const char* name) :width(width), height(height)
+Window::Window(unsigned int width, unsigned int height, const char *name)
+    : width(width), height(height)
 {
-	RECT rWindow;
-	rWindow.left = 100;
-	rWindow.right = width + rWindow.left;
-	rWindow.top = 100;
-	rWindow.bottom = height + rWindow.top;
-	// Automatic calculation of window height and width to client region
-	wis::check_windows(AdjustWindowRect(&rWindow, WS_OVERLAPPEDWINDOW, TRUE));
+    RECT rWindow;
+    rWindow.left = 100;
+    rWindow.right = width + rWindow.left;
+    rWindow.top = 100;
+    rWindow.bottom = height + rWindow.top;
+    // Automatic calculation of window height and width to client region
+    wis::check_windows(AdjustWindowRect(&rWindow, WS_OVERLAPPEDWINDOW, TRUE));
 
-	hWnd.reset(CreateWindowA(
-		WindowClass::GetName(), name,
-		WS_OVERLAPPEDWINDOW,
-		CW_USEDEFAULT, CW_USEDEFAULT,
-		rWindow.right - rWindow.left,
-		rWindow.bottom - rWindow.top,
-		nullptr, nullptr,
-		WindowClass::GetInstance(), this
-	));
+    hWnd.reset(CreateWindowA(
+            WindowClass::GetName(), name,
+            WS_OVERLAPPEDWINDOW,
+            CW_USEDEFAULT, CW_USEDEFAULT,
+            rWindow.right - rWindow.left,
+            rWindow.bottom - rWindow.top,
+            nullptr, nullptr,
+            WindowClass::GetInstance(), this));
 
-	// Error checks
-	wis::check_windows(!!hWnd);
-	ShowWindow(hWnd.get(), SW_SHOWDEFAULT);
+    // Error checks
+    wis::check_windows(!!hWnd);
+    ShowWindow(hWnd.get(), SW_SHOWDEFAULT);
 
-	Accelerator.reset(LoadAccelerators(WindowClass::GetInstance(), MAKEINTRESOURCE(IDR_ACCELERATOR1)));
+    Accelerator.reset(LoadAccelerators(WindowClass::GetInstance(), MAKEINTRESOURCE(IDR_ACCELERATOR1)));
 
-	// Init GUI (only one window supported)
-	//wis::check_windows(ImGui_ImplWin32_Init(hWnd.get()));
+    // Init GUI (only one window supported)
+    // wis::check_windows(ImGui_ImplWin32_Init(hWnd.get()));
 
-	RAWINPUTDEVICE rid;
-	rid.usUsagePage = 0x01; // mouse page
-	rid.usUsage = 0x02; // mouse usage
-	rid.dwFlags = 0;
-	rid.hwndTarget = nullptr;
-	wis::check_windows(RegisterRawInputDevices(&rid, 1, sizeof(rid)));
+    RAWINPUTDEVICE rid;
+    rid.usUsagePage = 0x01; // mouse page
+    rid.usUsage = 0x02; // mouse usage
+    rid.dwFlags = 0;
+    rid.hwndTarget = nullptr;
+    wis::check_windows(RegisterRawInputDevices(&rid, 1, sizeof(rid)));
 }
 Window::~Window()
 {
-	//ImGui_ImplWin32_Shutdown();
+    // ImGui_ImplWin32_Shutdown();
 }
 
 void Window::ChangeToFullScreen()
 {
-	SetMenu(hWnd.get(), nullptr);
-	auto st = GetWindowLong(hWnd.get(), GWL_STYLE);
-	auto stex = GetWindowLong(hWnd.get(), GWL_EXSTYLE);
-	SetWindowLong(hWnd.get(), GWL_STYLE,
-		st & ~(WS_CAPTION | WS_THICKFRAME));
-	SetWindowLong(hWnd.get(), GWL_EXSTYLE,
-		stex & ~(WS_EX_DLGMODALFRAME |
-			WS_EX_WINDOWEDGE | WS_EX_CLIENTEDGE | WS_EX_STATICEDGE));
+    SetMenu(hWnd.get(), nullptr);
+    auto st = GetWindowLong(hWnd.get(), GWL_STYLE);
+    auto stex = GetWindowLong(hWnd.get(), GWL_EXSTYLE);
+    SetWindowLong(hWnd.get(), GWL_STYLE,
+                  st & ~(WS_CAPTION | WS_THICKFRAME));
+    SetWindowLong(hWnd.get(), GWL_EXSTYLE,
+                  stex & ~(WS_EX_DLGMODALFRAME | WS_EX_WINDOWEDGE | WS_EX_CLIENTEDGE | WS_EX_STATICEDGE));
 
-	MONITORINFO monitor_info;
-	monitor_info.cbSize = sizeof(monitor_info);
-	GetMonitorInfo(MonitorFromWindow(hWnd.get(), MONITOR_DEFAULTTONEAREST),
-		&monitor_info);
+    MONITORINFO monitor_info;
+    monitor_info.cbSize = sizeof(monitor_info);
+    GetMonitorInfo(MonitorFromWindow(hWnd.get(), MONITOR_DEFAULTTONEAREST),
+                   &monitor_info);
 
-	
-	RECT window_rect(monitor_info.rcMonitor);
-	SetWindowPos(hWnd.get(), NULL, window_rect.left, window_rect.top,
-		window_rect.right - window_rect.left, window_rect.bottom - window_rect.top,
-		SWP_NOZORDER | SWP_NOACTIVATE | SWP_FRAMECHANGED);
+    RECT window_rect(monitor_info.rcMonitor);
+    SetWindowPos(hWnd.get(), NULL, window_rect.left, window_rect.top,
+                 window_rect.right - window_rect.left, window_rect.bottom - window_rect.top,
+                 SWP_NOZORDER | SWP_NOACTIVATE | SWP_FRAMECHANGED);
 }
 
 void Window::SetTitle(std::string_view title)
 {
-	wis::check_windows(SetWindowTextA(hWnd.get(), title.data()));
+    wis::check_windows(SetWindowTextA(hWnd.get(), title.data()));
 }
 
-void Window::EnableLoading() 
+void Window::EnableLoading()
 {
-	menu.EnableLoading();
+    menu.EnableLoading();
 }
 
 void Window::EnableCursor() noexcept
 {
-	cursorEnabled = true;
-	ShowCursor();
-	EnableImGuiMouse();
-	FreeCursor();
+    cursorEnabled = true;
+    ShowCursor();
+    EnableImGuiMouse();
+    FreeCursor();
 }
 void Window::DisableCursor() noexcept
 {
-	cursorEnabled = false;
-	HideCursor();
-	DisableImGuiMouse();
-	ConfineCursor();
+    cursorEnabled = false;
+    HideCursor();
+    DisableImGuiMouse();
+    ConfineCursor();
 }
 bool Window::CursorEnabled() const noexcept
 {
-	return cursorEnabled;
+    return cursorEnabled;
 }
 
 void Window::ConfineCursor() noexcept
 {
-	RECT rect;
-	GetClientRect(hWnd.get(), &rect);
-	MapWindowPoints(hWnd.get(), nullptr, reinterpret_cast<POINT*>(&rect), 2);
-	ClipCursor(&rect);
+    RECT rect;
+    GetClientRect(hWnd.get(), &rect);
+    MapWindowPoints(hWnd.get(), nullptr, reinterpret_cast<POINT *>(&rect), 2);
+    ClipCursor(&rect);
 }
 void Window::FreeCursor() noexcept
 {
-	ClipCursor(nullptr);
+    ClipCursor(nullptr);
 }
 void Window::HideCursor() noexcept
 {
-	while (::ShowCursor(FALSE) >= 0);
-	cursorShown = false;
+    while (::ShowCursor(FALSE) >= 0)
+        ;
+    cursorShown = false;
 }
 void Window::ShowCursor() noexcept
 {
-	while (::ShowCursor(TRUE) < 0);
-	cursorShown = true;
+    while (::ShowCursor(TRUE) < 0)
+        ;
+    cursorShown = true;
 }
-void Window::ShowImGuiMouse()noexcept
+void Window::ShowImGuiMouse() noexcept
 {
-	if (!cursorShown)
-		ShowCursor();
+    if (!cursorShown)
+        ShowCursor();
 }
 void Window::EnableImGuiMouse() noexcept
 {
-	//ImGui::GetIO().ConfigFlags &= ~ImGuiConfigFlags_NoMouse;
+    // ImGui::GetIO().ConfigFlags &= ~ImGuiConfigFlags_NoMouse;
 }
 void Window::DisableImGuiMouse() noexcept
 {
-	//ImGui::GetIO().ConfigFlags |= ImGuiConfigFlags_NoMouse;
+    // ImGui::GetIO().ConfigFlags |= ImGuiConfigFlags_NoMouse;
 }
 
-std::optional<WPARAM> Window::ProcessMessages()const noexcept
+std::optional<WPARAM> Window::ProcessMessages() const noexcept
 {
-	MSG msg;
-	while (PeekMessage(&msg, nullptr, 0, 0, PM_REMOVE))
-	{
-		if (!TranslateAccelerator(
-			hWnd.get(),  // handle to receiving window 
-			Accelerator.get(),    // handle to active accelerator table 
-			&msg))         // message data 
-		{
-			if (msg.message == WM_QUIT)
-			{
-				return msg.wParam;
-			}
+    MSG msg;
+    while (PeekMessage(&msg, nullptr, 0, 0, PM_REMOVE)) {
+        if (!TranslateAccelerator(
+                    hWnd.get(), // handle to receiving window
+                    Accelerator.get(), // handle to active accelerator table
+                    &msg)) // message data
+        {
+            if (msg.message == WM_QUIT) {
+                return msg.wParam;
+            }
 
-			TranslateMessage(&msg);
-			DispatchMessage(&msg);
-		}
-	}
-	if (!bActive)
-	{
-		WaitMessage();
-	}
-	return{};
+            TranslateMessage(&msg);
+            DispatchMessage(&msg);
+        }
+    }
+    if (!bActive) {
+        WaitMessage();
+    }
+    return {};
 }
 LRESULT WINAPI Window::HandleMsgSetup(HWND hWnd, UINT msg, WPARAM wParam, LPARAM lParam)
 {
-	// Create routine initializer
-	if (msg == WM_NCCREATE)
-	{
-		// Extract data from creation of window
-		const CREATESTRUCTW* const pCreate = reinterpret_cast<CREATESTRUCTW*>(lParam);
-		Window* const pWnd = static_cast<Window*>(pCreate->lpCreateParams);
-		// set WinAPI-managed user data to store ptr to win class
-		SetWindowLongPtr(hWnd, GWLP_USERDATA, reinterpret_cast<LONG_PTR>(pWnd));
-		// set msgproc to to non setup handle
-		SetWindowLongPtr(hWnd, GWLP_WNDPROC, reinterpret_cast<LONG_PTR>(&Window::HandleMsgThunk));
+    // Create routine initializer
+    if (msg == WM_NCCREATE) {
+        // Extract data from creation of window
+        const CREATESTRUCTW *const pCreate = reinterpret_cast<CREATESTRUCTW *>(lParam);
+        Window *const pWnd = static_cast<Window *>(pCreate->lpCreateParams);
+        // set WinAPI-managed user data to store ptr to win class
+        SetWindowLongPtr(hWnd, GWLP_USERDATA, reinterpret_cast<LONG_PTR>(pWnd));
+        // set msgproc to to non setup handle
+        SetWindowLongPtr(hWnd, GWLP_WNDPROC, reinterpret_cast<LONG_PTR>(&Window::HandleMsgThunk));
 
-		return pWnd->HandleMsg(hWnd, msg, wParam, lParam);
-	}
-	return DefWindowProc(hWnd, msg, wParam, lParam);
+        return pWnd->HandleMsg(hWnd, msg, wParam, lParam);
+    }
+    return DefWindowProc(hWnd, msg, wParam, lParam);
 }
 LRESULT WINAPI Window::HandleMsgThunk(HWND hWnd, UINT msg, WPARAM wParam, LPARAM lParam)
 {
-	// retrieve ptr to win class
-	Window* const pWnd = reinterpret_cast<Window*>(GetWindowLongPtr(hWnd, GWLP_USERDATA));
-	// forward msg to class handler
-	return pWnd->HandleMsg(hWnd, msg, wParam, lParam);
+    // retrieve ptr to win class
+    Window *const pWnd = reinterpret_cast<Window *>(GetWindowLongPtr(hWnd, GWLP_USERDATA));
+    // forward msg to class handler
+    return pWnd->HandleMsg(hWnd, msg, wParam, lParam);
 }
 LRESULT Window::HandleMsg(HWND hWnd, UINT msg, WPARAM wParam, LPARAM lParam)
 {
-	//if (ImGui_ImplWin32_WndProcHandler(hWnd, msg, wParam, lParam))
-	//{
-		//return true;
-	//}
-	//const auto& imio = ImGui::GetIO();
+    // if (ImGui_ImplWin32_WndProcHandler(hWnd, msg, wParam, lParam))
+    //{
+    // return true;
+    //}
+    // const auto& imio = ImGui::GetIO();
 
-	switch (msg)
-	{
-		// we don't want the DefProc to handle this message because
-		// we want our destructor to destroy the window, so return 0 instead of break
-	case WM_CLOSE:
-		PostQuitMessage(0);
-		return 0;
-		// clear keystate when window loses focus to prevent input getting "stuck"
-	case WM_KILLFOCUS:
-		kbd.ClearState();
-		break;
-	case WM_SYSCOMMAND:
-		if (wParam == SC_MINIMIZE)
-		{
-			bActive = false;
-		}
-		if (wParam == SC_RESTORE)
-		{
-			bActive = true;
-		}
-		break;
-	case WM_SIZE:
-		if (!LOWORD(lParam) || !HIWORD(lParam))
-			break;
-		width = LOWORD(lParam);
-		height = HIWORD(lParam);
-		events.push(Event::Resize);
-		break;
-	case WM_CREATE:
-		menu.Initialize(GetMenu(hWnd));
-		break;
-	case WM_COMMAND:
-		switch (MenuItems(LOWORD(wParam)))
-		{
-		case MenuItems::Load:
-			menu.DisableLoading();
-			events.push(Event::LoadAsset);
-			break;
-		case MenuItems::Exit:
-			PostQuitMessage(0);
-			return 0;
-		case MenuItems::ShowGrid:
-			menu.ToggleGrid();
-			break;
-		//case MenuItems::Style_VGUI:
-		//	if (menu.SetStyle(UT::Menu::Style::VGUI))
-		//		events.push(Event::Restyle);
-		//	break;
-		//case MenuItems::Style_Dark:
-		//	if (menu.SetStyle(UT::Menu::Style::Dark))
-		//		events.push(Event::Restyle);
-		//	break;
-		//case MenuItems::Style_Cherry:
-		//	if (menu.SetStyle(UT::Menu::Style::Cherry))
-		//		events.push(Event::Restyle);
-		//	break;
-		case MenuItems::PlayGame:
-			events.push(Event::Play);
-			break;
-		case MenuItems::About:
-			DialogBox(WindowClass::GetInstance(), MAKEINTRESOURCE(IDD_DIALOG1), hWnd, About);
-			break;
-		default:
-			break;
-		}
-		break;
-	case WM_ACTIVATE:
-		// confine/free cursor on window to foreground/background if cursor disabled
-		if (!cursorEnabled)
-		{
-			if (wParam & WA_ACTIVE)
-			{
-				ConfineCursor();
-				HideCursor();
-			}
-			else
-			{
-				FreeCursor();
-				ShowCursor();
-			}
-		}
-		break;
+    switch (msg) {
+        // we don't want the DefProc to handle this message because
+        // we want our destructor to destroy the window, so return 0 instead of break
+    case WM_CLOSE:
+        PostQuitMessage(0);
+        return 0;
+        // clear keystate when window loses focus to prevent input getting "stuck"
+    case WM_KILLFOCUS:
+        kbd.ClearState();
+        break;
+    case WM_SYSCOMMAND:
+        if (wParam == SC_MINIMIZE) {
+            bActive = false;
+        }
+        if (wParam == SC_RESTORE) {
+            bActive = true;
+        }
+        break;
+    case WM_SIZE:
+        if (!LOWORD(lParam) || !HIWORD(lParam))
+            break;
+        width = LOWORD(lParam);
+        height = HIWORD(lParam);
+        events.push(Event::Resize);
+        break;
+    case WM_CREATE:
+        menu.Initialize(GetMenu(hWnd));
+        break;
+    case WM_COMMAND:
+        switch (MenuItems(LOWORD(wParam))) {
+        case MenuItems::Load:
+            menu.DisableLoading();
+            events.push(Event::LoadAsset);
+            break;
+        case MenuItems::Exit:
+            PostQuitMessage(0);
+            return 0;
+        case MenuItems::ShowGrid:
+            menu.ToggleGrid();
+            break;
+        // case MenuItems::Style_VGUI:
+        //	if (menu.SetStyle(UT::Menu::Style::VGUI))
+        //		events.push(Event::Restyle);
+        //	break;
+        // case MenuItems::Style_Dark:
+        //	if (menu.SetStyle(UT::Menu::Style::Dark))
+        //		events.push(Event::Restyle);
+        //	break;
+        // case MenuItems::Style_Cherry:
+        //	if (menu.SetStyle(UT::Menu::Style::Cherry))
+        //		events.push(Event::Restyle);
+        //	break;
+        case MenuItems::PlayGame:
+            events.push(Event::Play);
+            break;
+        case MenuItems::About:
+            DialogBox(WindowClass::GetInstance(), MAKEINTRESOURCE(IDD_DIALOG1), hWnd, About);
+            break;
+        default:
+            break;
+        }
+        break;
+    case WM_ACTIVATE:
+        // confine/free cursor on window to foreground/background if cursor disabled
+        if (!cursorEnabled) {
+            if (wParam & WA_ACTIVE) {
+                ConfineCursor();
+                HideCursor();
+            } else {
+                FreeCursor();
+                ShowCursor();
+            }
+        }
+        break;
 
-		/*********** KEYBOARD MESSAGES ***********/
-	case WM_KEYDOWN:
-		// syskey commands need to be handled to track ALT key (VK_MENU) and F10
-	case WM_SYSKEYDOWN:
-		// stifle this keyboard message if imgui wants to capture
-		//if (imio.WantCaptureKeyboard)
-		//{
-		//	break;
-		//}
-		if (!(lParam & 0x40000000) || kbd.AutorepeatIsEnabled()) // filter autorepeat
-		{
-			kbd.OnKeyPressed(static_cast<unsigned char>(wParam));
-		}
-		break;
-	case WM_KEYUP:
-	case WM_SYSKEYUP:
-		// stifle this keyboard message if imgui wants to capture
-		//if (imio.WantCaptureKeyboard)
-		//{
-		//	break;
-		//}
-		kbd.OnKeyReleased(static_cast<unsigned char>(wParam));
-		break;
-	case WM_CHAR:
-		// stifle this keyboard message if imgui wants to capture
-		//if (imio.WantCaptureKeyboard)
-		//{
-		//	break;
-		//}
-		kbd.OnChar(static_cast<unsigned char>(wParam));
-		break;
-		/*********** END KEYBOARD MESSAGES ***********/
+        /*********** KEYBOARD MESSAGES ***********/
+    case WM_KEYDOWN:
+        // syskey commands need to be handled to track ALT key (VK_MENU) and F10
+    case WM_SYSKEYDOWN:
+        // stifle this keyboard message if imgui wants to capture
+        // if (imio.WantCaptureKeyboard)
+        //{
+        //	break;
+        //}
+        if (!(lParam & 0x40000000) || kbd.AutorepeatIsEnabled()) // filter autorepeat
+        {
+            kbd.OnKeyPressed(static_cast<unsigned char>(wParam));
+        }
+        break;
+    case WM_KEYUP:
+    case WM_SYSKEYUP:
+        // stifle this keyboard message if imgui wants to capture
+        // if (imio.WantCaptureKeyboard)
+        //{
+        //	break;
+        //}
+        kbd.OnKeyReleased(static_cast<unsigned char>(wParam));
+        break;
+    case WM_CHAR:
+        // stifle this keyboard message if imgui wants to capture
+        // if (imio.WantCaptureKeyboard)
+        //{
+        //	break;
+        //}
+        kbd.OnChar(static_cast<unsigned char>(wParam));
+        break;
+        /*********** END KEYBOARD MESSAGES ***********/
 
-		/************* MOUSE MESSAGES ****************/
-	case WM_MOUSEMOVE:
-	{
-		const POINTS pt = MAKEPOINTS(lParam);
-		// cursorless exclusive gets first dibs
-		if (!cursorEnabled)
-		{
-			if (!mouse.IsInWindow())
-			{
-				SetCapture(hWnd);
-				mouse.OnMouseEnter();
-				HideCursor();
-			}
-			break;
-		}
-		// stifle this mouse message if imgui wants to capture
-		//if (imio.WantCaptureMouse)
-		//{
-		//	ShowImGuiMouse();
-		//	break;
-		//}
-		if (cursorShown && !cursorActive)
-			HideCursor();
+        /************* MOUSE MESSAGES ****************/
+    case WM_MOUSEMOVE: {
+        const POINTS pt = MAKEPOINTS(lParam);
+        // cursorless exclusive gets first dibs
+        if (!cursorEnabled) {
+            if (!mouse.IsInWindow()) {
+                SetCapture(hWnd);
+                mouse.OnMouseEnter();
+                HideCursor();
+            }
+            break;
+        }
+        // stifle this mouse message if imgui wants to capture
+        // if (imio.WantCaptureMouse)
+        //{
+        //	ShowImGuiMouse();
+        //	break;
+        //}
+        if (cursorShown && !cursorActive)
+            HideCursor();
 
-		// in client region -> log move, and log enter + capture mouse (if not previously in window)
-		if (pt.x >= 0 && pt.x < width && pt.y >= 0 && pt.y < height)
-		{
-			mouse.OnMouseMove(pt.x, pt.y);
-			if (!mouse.IsInWindow())
-			{
-				SetCapture(hWnd);
-				mouse.OnMouseEnter();
-			}
-		}
-		// not in client -> log move / maintain capture if button down
-		else
-		{
-			if (wParam & (MK_LBUTTON | MK_RBUTTON))
-			{
-				mouse.OnMouseMove(pt.x, pt.y);
-			}
-			// button up -> release capture / log event for leaving
-			else
-			{
-				ReleaseCapture();
-				mouse.OnMouseLeave();
-			}
-		}
-		break;
-	}
-	case WM_LBUTTONDOWN:
-	{
-		SetForegroundWindow(hWnd);
-		if (!cursorEnabled)
-		{
-			ConfineCursor();
-			HideCursor();
-		}
-		// stifle this mouse message if imgui wants to capture
-		//if (imio.WantCaptureMouse)
-		//{
-		//	break;
-		//}
-		const POINTS pt = MAKEPOINTS(lParam);
-		mouse.OnLeftPressed(pt.x, pt.y);
-		break;
-	}
-	case WM_RBUTTONDOWN:
-	{
-		// stifle this mouse message if imgui wants to capture
-		//if (imio.WantCaptureMouse)
-		//{
-		//	break;
-		//}
-		const POINTS pt = MAKEPOINTS(lParam);
-		mouse.OnRightPressed(pt.x, pt.y);
-		break;
-	}
-	case WM_LBUTTONUP:
-	{
-		const POINTS pt = MAKEPOINTS(lParam);
-		mouse.OnLeftReleased(pt.x, pt.y);
-		// release mouse if outside of window
-		if (pt.x < 0 || pt.x >= width || pt.y < 0 || pt.y >= height)
-		{
-			ReleaseCapture();
-			mouse.OnMouseLeave();
-		}
-		break;
-	}
-	case WM_RBUTTONUP:
-	{
-		const POINTS pt = MAKEPOINTS(lParam);
-		mouse.OnRightReleased(pt.x, pt.y);
-		// release mouse if outside of window
-		if (pt.x < 0 || pt.x >= width || pt.y < 0 || pt.y >= height)
-		{
-			ReleaseCapture();
-			mouse.OnMouseLeave();
-		}
-		break;
-	}
-	case WM_MOUSEWHEEL:
-	{
-		// stifle this mouse message if imgui wants to capture
-		//if (imio.WantCaptureMouse)
-		//{
-		//	break;
-		//}
-		const POINTS pt = MAKEPOINTS(lParam);
-		const int delta = GET_WHEEL_DELTA_WPARAM(wParam);
-		mouse.OnWheelDelta(pt.x, pt.y, delta);
-		break;
-	}
-	/************** END MOUSE MESSAGES **************/
+        // in client region -> log move, and log enter + capture mouse (if not previously in window)
+        if (pt.x >= 0 && pt.x < width && pt.y >= 0 && pt.y < height) {
+            mouse.OnMouseMove(pt.x, pt.y);
+            if (!mouse.IsInWindow()) {
+                SetCapture(hWnd);
+                mouse.OnMouseEnter();
+            }
+        }
+        // not in client -> log move / maintain capture if button down
+        else {
+            if (wParam & (MK_LBUTTON | MK_RBUTTON)) {
+                mouse.OnMouseMove(pt.x, pt.y);
+            }
+            // button up -> release capture / log event for leaving
+            else {
+                ReleaseCapture();
+                mouse.OnMouseLeave();
+            }
+        }
+        break;
+    }
+    case WM_LBUTTONDOWN: {
+        SetForegroundWindow(hWnd);
+        if (!cursorEnabled) {
+            ConfineCursor();
+            HideCursor();
+        }
+        // stifle this mouse message if imgui wants to capture
+        // if (imio.WantCaptureMouse)
+        //{
+        //	break;
+        //}
+        const POINTS pt = MAKEPOINTS(lParam);
+        mouse.OnLeftPressed(pt.x, pt.y);
+        break;
+    }
+    case WM_RBUTTONDOWN: {
+        // stifle this mouse message if imgui wants to capture
+        // if (imio.WantCaptureMouse)
+        //{
+        //	break;
+        //}
+        const POINTS pt = MAKEPOINTS(lParam);
+        mouse.OnRightPressed(pt.x, pt.y);
+        break;
+    }
+    case WM_LBUTTONUP: {
+        const POINTS pt = MAKEPOINTS(lParam);
+        mouse.OnLeftReleased(pt.x, pt.y);
+        // release mouse if outside of window
+        if (pt.x < 0 || pt.x >= width || pt.y < 0 || pt.y >= height) {
+            ReleaseCapture();
+            mouse.OnMouseLeave();
+        }
+        break;
+    }
+    case WM_RBUTTONUP: {
+        const POINTS pt = MAKEPOINTS(lParam);
+        mouse.OnRightReleased(pt.x, pt.y);
+        // release mouse if outside of window
+        if (pt.x < 0 || pt.x >= width || pt.y < 0 || pt.y >= height) {
+            ReleaseCapture();
+            mouse.OnMouseLeave();
+        }
+        break;
+    }
+    case WM_MOUSEWHEEL: {
+        // stifle this mouse message if imgui wants to capture
+        // if (imio.WantCaptureMouse)
+        //{
+        //	break;
+        //}
+        const POINTS pt = MAKEPOINTS(lParam);
+        const int delta = GET_WHEEL_DELTA_WPARAM(wParam);
+        mouse.OnWheelDelta(pt.x, pt.y, delta);
+        break;
+    }
+    /************** END MOUSE MESSAGES **************/
 
-	/************** RAW MOUSE MESSAGES **************/
-	case WM_INPUT:
-	{
-		if (!mouse.RawEnabled())
-		{
-			break;
-		}
-		UINT size = 0;
-		// first get the size of the input data
-		if (GetRawInputData(
-			reinterpret_cast<HRAWINPUT>(lParam),
-			RID_INPUT,
-			nullptr,
-			&size,
-			sizeof(RAWINPUTHEADER)) == -1)
-		{
-			// bail msg processing if error
-			break;
-		}
-		rawBuffer.resize(size);
-		// read in the input data
-		if (GetRawInputData(
-			reinterpret_cast<HRAWINPUT>(lParam),
-			RID_INPUT,
-			rawBuffer.data(),
-			&size,
-			sizeof(RAWINPUTHEADER)) != size)
-		{
-			// bail msg processing if error
-			break;
-		}
-		// process the raw input data
-		auto& ri = reinterpret_cast<const RAWINPUT&>(*rawBuffer.data());
-		if (ri.header.dwType == RIM_TYPEMOUSE &&
-			(ri.data.mouse.lLastX != 0 || ri.data.mouse.lLastY != 0))
-		{
-			mouse.OnRawDelta(ri.data.mouse.lLastX, ri.data.mouse.lLastY);
-		}
-		break;
-	}
-	/************** END RAW MOUSE MESSAGES **************/
-	}
+    /************** RAW MOUSE MESSAGES **************/
+    case WM_INPUT: {
+        if (!mouse.RawEnabled()) {
+            break;
+        }
+        UINT size = 0;
+        // first get the size of the input data
+        if (GetRawInputData(
+                    reinterpret_cast<HRAWINPUT>(lParam),
+                    RID_INPUT,
+                    nullptr,
+                    &size,
+                    sizeof(RAWINPUTHEADER)) == -1) {
+            // bail msg processing if error
+            break;
+        }
+        rawBuffer.resize(size);
+        // read in the input data
+        if (GetRawInputData(
+                    reinterpret_cast<HRAWINPUT>(lParam),
+                    RID_INPUT,
+                    rawBuffer.data(),
+                    &size,
+                    sizeof(RAWINPUTHEADER)) != size) {
+            // bail msg processing if error
+            break;
+        }
+        // process the raw input data
+        auto &ri = reinterpret_cast<const RAWINPUT &>(*rawBuffer.data());
+        if (ri.header.dwType == RIM_TYPEMOUSE &&
+            (ri.data.mouse.lLastX != 0 || ri.data.mouse.lLastY != 0)) {
+            mouse.OnRawDelta(ri.data.mouse.lLastX, ri.data.mouse.lLastY);
+        }
+        break;
+    }
+        /************** END RAW MOUSE MESSAGES **************/
+    }
 
-	return DefWindowProc(hWnd, msg, wParam, lParam);
+    return DefWindowProc(hWnd, msg, wParam, lParam);
 }

--- a/examples/hello-triangle-winrt/app.cpp
+++ b/examples/hello-triangle-winrt/app.cpp
@@ -4,206 +4,191 @@
 #include <fstream>
 #include <DirectXMath.h>
 
-
-struct LogProvider : public wis::LogLayer
-{
-	virtual void Log(wis::Severity sev, std::string message, wis::source_location sl = wis::source_location::current())override
-	{
-		std::cout << wis::format("[{}]: {}\n", wis::severity_strings[+sev], message);
-	};
+struct LogProvider : public wis::LogLayer {
+    virtual void Log(wis::Severity sev, std::string message, wis::source_location sl = wis::source_location::current()) override
+    {
+        std::cout << wis::format("[{}]: {}\n", wis::severity_strings[+sev], message);
+    };
 };
 
 constexpr wis::ApplicationInfo app_info{
-	.application_name = "example",
-		.engine_name = "none",
+    .application_name = "example",
+    .engine_name = "none",
 };
 
 // not WinRT Compatible
 template<class ShaderTy>
 auto LoadShader(std::filesystem::path p)
 {
-	if constexpr (ShaderTy::language == wis::ShaderLang::dxil)
-		p += ".cso";
-	else if constexpr (ShaderTy::language == wis::ShaderLang::spirv)
-		p += ".spv";
+    if constexpr (ShaderTy::language == wis::ShaderLang::dxil)
+        p += ".cso";
+    else if constexpr (ShaderTy::language == wis::ShaderLang::spirv)
+        p += ".spv";
 
-	std::ifstream t{ p, std::ios::binary };
-	t.seekg(0, std::ios::end);
-	size_t size = t.tellg();
-	wis::shared_blob ret{ size };
-	t.seekg(0);
-	t.read(ret.data<char>(), size);
-	return ret;
+    std::ifstream t{ p, std::ios::binary };
+    t.seekg(0, std::ios::end);
+    size_t size = t.tellg();
+    wis::shared_blob ret{ size };
+    t.seekg(0);
+    t.read(ret.data<char>(), size);
+    return ret;
 }
 
 template<class T>
-std::span<std::byte> RawView(T& data)
+std::span<std::byte> RawView(T &data)
 {
-	return { (std::byte*)&data, sizeof(T) };
+    return { (std::byte *)&data, sizeof(T) };
 }
 
 Test::App::App()
 {
 }
 
-void Test::App::Initialize(IUnknown* core_window, uint32_t xwidth, uint32_t xheight)
+void Test::App::Initialize(IUnknown *core_window, uint32_t xwidth, uint32_t xheight)
 {
-	width = xwidth;
-	height = xheight;
-	wis::LibLogger::SetLogLayer(std::make_shared<LogProvider>());
+    width = xwidth;
+    height = xheight;
+    wis::LibLogger::SetLogLayer(std::make_shared<LogProvider>());
 
-	factory.emplace(app_info);
+    factory.emplace(app_info);
 
-	for (auto&& a : factory->EnumerateAdapters(wis::AdapterPreference::Performance))
-	{
-		auto desc = a.GetDesc();
+    for (auto &&a : factory->EnumerateAdapters(wis::AdapterPreference::Performance)) {
+        auto desc = a.GetDesc();
 
-		if (desc.IsSoftware())
-			wis::lib_warn("Loading WARP adapter");
+        if (desc.IsSoftware())
+            wis::lib_warn("Loading WARP adapter");
 
-		std::cout << desc.to_string();
+        std::cout << desc.to_string();
 
-		if (device.Initialize(a))
-		{
-			allocator = wis::ResourceAllocator{ device, a };
-			break;
-		}
-	}
+        if (device.Initialize(a)) {
+            allocator = wis::ResourceAllocator{ device, a };
+            break;
+        }
+    }
 
-	queue = device.CreateCommandQueue();
+    queue = device.CreateCommandQueue();
 
-	swap = device.CreateSwapchain(queue, wis::SwapchainOptions{
-			uint32_t(width),
-			uint32_t(height),
-			wis::SwapchainOptions::default_frames,
-			wis::SwapchainOptions::default_format,
-			true
-		}, wis::SurfaceParameters{ core_window });
+    swap = device.CreateSwapchain(queue, wis::SwapchainOptions{ uint32_t(width), uint32_t(height), wis::SwapchainOptions::default_frames, wis::SwapchainOptions::default_format, true }, wis::SurfaceParameters{ core_window });
 
-	fence = device.CreateFence();
-	context = device.CreateCommandList(wis::QueueType::direct);
+    fence = device.CreateFence();
+    context = device.CreateCommandList(wis::QueueType::direct);
 
-	std::array cas2{
-		wis::ColorAttachment {
-			.format = wis::SwapchainOptions::default_format,
-				.load = wis::PassLoadOperation::clear
-		},
-		wis::ColorAttachment {
-			.format = wis::SwapchainOptions::default_format,
-				.load = wis::PassLoadOperation::clear
-		}
-	};
+    std::array cas2{
+        wis::ColorAttachment{
+                .format = wis::SwapchainOptions::default_format,
+                .load = wis::PassLoadOperation::clear },
+        wis::ColorAttachment{
+                .format = wis::SwapchainOptions::default_format,
+                .load = wis::PassLoadOperation::clear }
+    };
 
-	render_pass = device.CreateRenderPass({ width, height }, { cas2.data(), swap.StereoSupported() + 1u });
+    render_pass = device.CreateRenderPass({ width, height }, { cas2.data(), swap.StereoSupported() + 1u });
 
-	vs = device.CreateShader(LoadShader<wis::Shader>(SHADER_DIR "/example.vs"), wis::ShaderType::vertex);
-	ps = device.CreateShader(LoadShader<wis::Shader>(SHADER_DIR "/example.ps"), wis::ShaderType::pixel);
+    vs = device.CreateShader(LoadShader<wis::Shader>(SHADER_DIR "/example.vs"), wis::ShaderType::vertex);
+    ps = device.CreateShader(LoadShader<wis::Shader>(SHADER_DIR "/example.ps"), wis::ShaderType::pixel);
 
-	root = device.CreateRootSignature();//empty
+    root = device.CreateRootSignature(); // empty
 
-	static constexpr std::array<wis::InputLayoutDesc, 2> ia{
-		wis::InputLayoutDesc{ 0, "POSITION", 0, wis::DataFormat::r32g32b32_float, 0, 0, wis::InputClassification::vertex, 0 },
-		wis::InputLayoutDesc{ 1, "COLOR", 0, wis::DataFormat::r32g32b32a32_float, 0, 12, wis::InputClassification::vertex, 0 }
-	};
+    static constexpr std::array<wis::InputLayoutDesc, 2> ia{
+        wis::InputLayoutDesc{ 0, "POSITION", 0, wis::DataFormat::r32g32b32_float, 0, 0, wis::InputClassification::vertex, 0 },
+        wis::InputLayoutDesc{ 1, "COLOR", 0, wis::DataFormat::r32g32b32a32_float, 0, 12, wis::InputClassification::vertex, 0 }
+    };
 
-	wis::GraphicsPipelineDesc desc{ root };
-	desc.SetVS(vs);
-	desc.SetPS(ps);
-	desc.SetRenderPass(render_pass);
-	pipeline = device.CreateGraphicsPipeline(std::move(desc), ia);
+    wis::GraphicsPipelineDesc desc{ root };
+    desc.SetVS(vs);
+    desc.SetPS(ps);
+    desc.SetRenderPass(render_pass);
+    pipeline = device.CreateGraphicsPipeline(std::move(desc), ia);
 
-	struct Vertex
-	{
-		DirectX::XMFLOAT3 pos;
-		DirectX::XMFLOAT4 col;
-	};
-	auto aspect_ratio = float(width) / float(height);
-	Vertex triangleVertices[] =
-	{
-		{ { 0.0f, 0.25f * aspect_ratio , 0.0f }, { 1.0f, 0.0f, 0.0f, 1.0f } },
-		{ { 0.25f, -0.25f * aspect_ratio , 0.0f }, { 0.0f, 1.0f, 0.0f, 1.0f } },
-		{ { -0.25f, -0.25f * aspect_ratio , 0.0f }, { 0.0f, 0.0f, 1.0f, 1.0f } }
-	};
+    struct Vertex {
+        DirectX::XMFLOAT3 pos;
+        DirectX::XMFLOAT4 col;
+    };
+    auto aspect_ratio = float(width) / float(height);
+    Vertex triangleVertices[] = {
+        { { 0.0f, 0.25f * aspect_ratio, 0.0f }, { 1.0f, 0.0f, 0.0f, 1.0f } },
+        { { 0.25f, -0.25f * aspect_ratio, 0.0f }, { 0.0f, 1.0f, 0.0f, 1.0f } },
+        { { -0.25f, -0.25f * aspect_ratio, 0.0f }, { 0.0f, 0.0f, 1.0f, 1.0f } }
+    };
 
-	vertex_buffer = allocator.CreatePersistentBuffer(sizeof(triangleVertices), wis::BufferFlags::VertexBuffer);
+    vertex_buffer = allocator.CreatePersistentBuffer(sizeof(triangleVertices), wis::BufferFlags::VertexBuffer);
 
-	auto upl_vbuf = allocator.CreateUploadBuffer(sizeof(triangleVertices));
-	upl_vbuf.UpdateSubresource(RawView(triangleVertices));
+    auto upl_vbuf = allocator.CreateUploadBuffer(sizeof(triangleVertices));
+    upl_vbuf.UpdateSubresource(RawView(triangleVertices));
 
-	context.Reset();
-	context.CopyBuffer(upl_vbuf, vertex_buffer, sizeof(triangleVertices));
-	context.BufferBarrier({
-		.access_before = wis::ResourceAccess::CopyDest,
-		.access_after = wis::ResourceAccess::VertexBuffer
-		}, vertex_buffer);
-	context.Close();
+    context.Reset();
+    context.CopyBuffer(upl_vbuf, vertex_buffer, sizeof(triangleVertices));
+    context.BufferBarrier({ .access_before = wis::ResourceAccess::CopyDest,
+                            .access_after = wis::ResourceAccess::VertexBuffer },
+                          vertex_buffer);
+    context.Close();
 
-	queue.ExecuteCommandList(context);
-	WaitForGPU();
+    queue.ExecuteCommandList(context);
+    WaitForGPU();
 
-	vb = vertex_buffer.GetVertexBufferView(sizeof(Vertex));
-	context.SetPipeline(pipeline);
+    vb = vertex_buffer.GetVertexBufferView(sizeof(Vertex));
+    context.SetPipeline(pipeline);
 
-	auto x = swap.GetRenderTargets();
-	for (size_t i = 0; i < x.size(); i++)
-	{
-		rtvs[i] = device.CreateRenderTargetView(x[i]);
-		if (swap.StereoSupported())
-			rtvs2[i] = device.CreateRenderTargetView(x[i], { .base_layer = 1 });
-	}
+    auto x = swap.GetRenderTargets();
+    for (size_t i = 0; i < x.size(); i++) {
+        rtvs[i] = device.CreateRenderTargetView(x[i]);
+        if (swap.StereoSupported())
+            rtvs2[i] = device.CreateRenderTargetView(x[i], { .base_layer = 1 });
+    }
 }
 Test::App::~App()
 {
-	WaitForGPU();
+    WaitForGPU();
 }
 void Test::App::Frame()
 {
-	context.Reset();
-	auto back = swap.GetBackBuffer();
+    context.Reset();
+    auto back = swap.GetBackBuffer();
 
-	context.TextureBarrier({
-		.state_before = wis::TextureState::Present,
-		.state_after = wis::TextureState::RenderTarget,
-		.access_before = wis::ResourceAccess::Common,
-		.access_after = wis::ResourceAccess::RenderTarget,
-		}, back);
+    context.TextureBarrier({
+                                   .state_before = wis::TextureState::Present,
+                                   .state_after = wis::TextureState::RenderTarget,
+                                   .access_before = wis::ResourceAccess::Common,
+                                   .access_after = wis::ResourceAccess::RenderTarget,
+                           },
+                           back);
 
-	constexpr wis::ColorClear color{ 0.0f, 0.2f, 0.4f, 1.0f };
-	constexpr wis::ColorClear color2{ 1.0f, 0.2f, 0.4f, 1.0f };
-	std::array rtvsx{
-		std::pair{rtvs[swap.GetNextIndex()], color},
-		std::pair{rtvs2[swap.GetNextIndex()], color2}
-	};
+    constexpr wis::ColorClear color{ 0.0f, 0.2f, 0.4f, 1.0f };
+    constexpr wis::ColorClear color2{ 1.0f, 0.2f, 0.4f, 1.0f };
+    std::array rtvsx{
+        std::pair{ rtvs[swap.GetNextIndex()], color },
+        std::pair{ rtvs2[swap.GetNextIndex()], color2 }
+    };
 
-	context.SetGraphicsDescriptorSet(root);
-	context.RSSetViewport({ float(width), float(height) });
-	context.RSSetScissorRect({ long(width), long(height) });
-	context.IASetPrimitiveTopology(wis::PrimitiveTopology::trianglelist);
-	context.IASetVertexBuffers({ &vb, 1 });
+    context.SetGraphicsDescriptorSet(root);
+    context.RSSetViewport({ float(width), float(height) });
+    context.RSSetScissorRect({ long(width), long(height) });
+    context.IASetPrimitiveTopology(wis::PrimitiveTopology::trianglelist);
+    context.IASetVertexBuffers({ &vb, 1 });
 
-	context.BeginRenderPass(render_pass, { rtvsx.data(), swap.StereoSupported() + 1u });
-	context.DrawInstanced(3);
-	context.EndRenderPass();
+    context.BeginRenderPass(render_pass, { rtvsx.data(), swap.StereoSupported() + 1u });
+    context.DrawInstanced(3);
+    context.EndRenderPass();
 
-	context.TextureBarrier({
-		.state_before = wis::TextureState::RenderTarget,
-		.state_after = wis::TextureState::Present,
-		.access_before = wis::ResourceAccess::RenderTarget,
-		.access_after = wis::ResourceAccess::Common,
-		}, back);
-	context.Close();
-	queue.ExecuteCommandList(context);
+    context.TextureBarrier({
+                                   .state_before = wis::TextureState::RenderTarget,
+                                   .state_after = wis::TextureState::Present,
+                                   .access_before = wis::ResourceAccess::RenderTarget,
+                                   .access_after = wis::ResourceAccess::Common,
+                           },
+                           back);
+    context.Close();
+    queue.ExecuteCommandList(context);
 
-	swap.Present();
+    swap.Present();
 
-	WaitForGPU();
+    WaitForGPU();
 }
-
 
 void Test::App::WaitForGPU()
 {
-	const uint64_t vfence = fence_value;
-	queue.Signal(fence, vfence);
-	fence_value++;
-	fence.Wait(vfence);
+    const uint64_t vfence = fence_value;
+    queue.Signal(fence, vfence);
+    fence_value++;
+    fence.Wait(vfence);
 }

--- a/examples/hello-triangle-winrt/app.h
+++ b/examples/hello-triangle-winrt/app.h
@@ -2,41 +2,44 @@
 #include <wisdom/wisdom.h>
 
 namespace Test {
-	class App
-	{
-	public:
-		App();
-		~App();
-		void Initialize(IUnknown* core_window, uint32_t width, uint32_t height);
-	public:
-		void Frame();
-	private:
-		void WaitForGPU();
-	private:
-		uint32_t width = 0;
-		uint32_t height = 0;
+class App
+{
+public:
+    App();
+    ~App();
+    void Initialize(IUnknown *core_window, uint32_t width, uint32_t height);
 
-		std::optional<wis::Factory> factory;
+public:
+    void Frame();
 
-		wis::Device device;
-		wis::CommandQueue queue;
-		wis::SwapChain swap;
+private:
+    void WaitForGPU();
 
-		wis::CommandList context;
-		wis::Fence fence;
-		wis::ResourceAllocator allocator;
+private:
+    uint32_t width = 0;
+    uint32_t height = 0;
 
-		wis::Shader vs;
-		wis::Shader ps;
+    std::optional<wis::Factory> factory;
 
-		wis::RootSignature root;
-		wis::PipelineState pipeline;
-		wis::VertexBufferView vb;
-		wis::RenderTargetView rtvs[2];
-		wis::RenderTargetView rtvs2[2];
+    wis::Device device;
+    wis::CommandQueue queue;
+    wis::SwapChain swap;
 
-		wis::Buffer vertex_buffer;
-		wis::RenderPass render_pass;
-		uint64_t fence_value = 1;
-	};
-}
+    wis::CommandList context;
+    wis::Fence fence;
+    wis::ResourceAllocator allocator;
+
+    wis::Shader vs;
+    wis::Shader ps;
+
+    wis::RootSignature root;
+    wis::PipelineState pipeline;
+    wis::VertexBufferView vb;
+    wis::RenderTargetView rtvs[2];
+    wis::RenderTargetView rtvs2[2];
+
+    wis::Buffer vertex_buffer;
+    wis::RenderPass render_pass;
+    uint64_t fence_value = 1;
+};
+} // namespace Test

--- a/examples/hello-triangle-winrt/entry_main.cpp
+++ b/examples/hello-triangle-winrt/entry_main.cpp
@@ -1,10 +1,10 @@
 #include "window.h"
 
 int WINAPI wWinMain(
-    _In_ HINSTANCE /*hInstance*/,
-    _In_ HINSTANCE /*hPrevInstance*/,
-    _In_ LPWSTR    /*lpCmdLine*/,
-    _In_ int       /*nCmdShow*/
+        _In_ HINSTANCE /*hInstance*/,
+        _In_ HINSTANCE /*hPrevInstance*/,
+        _In_ LPWSTR /*lpCmdLine*/,
+        _In_ int /*nCmdShow*/
 )
 {
     winrt::init_apartment();

--- a/examples/hello-triangle-winrt/pch.h
+++ b/examples/hello-triangle-winrt/pch.h
@@ -52,31 +52,30 @@
 // If using the DirectX Tool Kit for DX12, uncomment this line:
 //#include "GraphicsMemory.h"
 
-namespace DX
+namespace DX {
+// Helper class for COM exceptions
+class com_exception : public std::exception
 {
-    // Helper class for COM exceptions
-    class com_exception : public std::exception
+public:
+    com_exception(HRESULT hr) noexcept
+        : result(hr) { }
+
+    const char *what() const override
     {
-    public:
-        com_exception(HRESULT hr) noexcept : result(hr) {}
+        static char s_str[64] = {};
+        sprintf_s(s_str, "Failure with HRESULT of %08X", static_cast<unsigned int>(result));
+        return s_str;
+    }
 
-        const char* what() const override
-        {
-            static char s_str[64] = {};
-            sprintf_s(s_str, "Failure with HRESULT of %08X", static_cast<unsigned int>(result));
-            return s_str;
-        }
+private:
+    HRESULT result;
+};
 
-    private:
-        HRESULT result;
-    };
-
-    // Helper utility converts D3D API failures into exceptions.
-    inline void ThrowIfFailed(HRESULT hr)
-    {
-        if (FAILED(hr))
-        {
-            throw com_exception(hr);
-        }
+// Helper utility converts D3D API failures into exceptions.
+inline void ThrowIfFailed(HRESULT hr)
+{
+    if (FAILED(hr)) {
+        throw com_exception(hr);
     }
 }
+} // namespace DX

--- a/examples/hello-triangle-winrt/window.h
+++ b/examples/hello-triangle-winrt/window.h
@@ -13,405 +13,359 @@ using namespace winrt::Windows::Foundation;
 using namespace winrt::Windows::Graphics::Display;
 using namespace DirectX;
 
-
-
 // Exit helper
 void ExitGame() noexcept
 {
-	winrt::Windows::ApplicationModel::Core::CoreApplication::Exit();
+    winrt::Windows::ApplicationModel::Core::CoreApplication::Exit();
 }
 
-namespace
+namespace {
+inline int ConvertDipsToPixels(float dips, float dpi) noexcept
 {
-	inline int ConvertDipsToPixels(float dips, float dpi) noexcept
-	{
-		return int(dips * dpi / 96.f + 0.5f);
-	}
-
-	inline float ConvertPixelsToDips(int pixels, float dpi) noexcept
-	{
-		return (float(pixels) * 96.f / dpi);
-	}
+    return int(dips * dpi / 96.f + 0.5f);
 }
 
+inline float ConvertPixelsToDips(int pixels, float dpi) noexcept
+{
+    return (float(pixels) * 96.f / dpi);
+}
+} // namespace
 
 // Window size helper
-_Use_decl_annotations_
-void GetWindowBounds(::IUnknown* window, RECT* rect)
+_Use_decl_annotations_ void GetWindowBounds(::IUnknown *window, RECT *rect)
 {
-	if (!rect)
-		return;
+    if (!rect)
+        return;
 
-	*rect = {};
+    *rect = {};
 
-	if (!window)
-		return;
+    if (!window)
+        return;
 
-	CoreWindow cw{ nullptr };
-	if (FAILED(window->QueryInterface(winrt::guid_of<CoreWindow>(), winrt::put_abi(cw))))
-		return;
+    CoreWindow cw{ nullptr };
+    if (FAILED(window->QueryInterface(winrt::guid_of<CoreWindow>(), winrt::put_abi(cw))))
+        return;
 
-	auto b = cw.Bounds();
+    auto b = cw.Bounds();
 
-	auto currentDisplayInformation = DisplayInformation::GetForCurrentView();
-	float dpi = currentDisplayInformation.LogicalDpi();
+    auto currentDisplayInformation = DisplayInformation::GetForCurrentView();
+    float dpi = currentDisplayInformation.LogicalDpi();
 
-	const int x = ConvertDipsToPixels(b.X, dpi);
-	const int y = ConvertDipsToPixels(b.Y, dpi);
-	const int w = ConvertDipsToPixels(b.Width, dpi);
-	const int h = ConvertDipsToPixels(b.Height, dpi);
+    const int x = ConvertDipsToPixels(b.X, dpi);
+    const int y = ConvertDipsToPixels(b.Y, dpi);
+    const int w = ConvertDipsToPixels(b.Width, dpi);
+    const int h = ConvertDipsToPixels(b.Height, dpi);
 
-	rect->left = static_cast<long>(x);
-	rect->top = static_cast<long>(y);
-	rect->right = static_cast<long>(x + w);
-	rect->bottom = static_cast<long>(y + h);
+    rect->left = static_cast<long>(x);
+    rect->top = static_cast<long>(y);
+    rect->right = static_cast<long>(x + w);
+    rect->bottom = static_cast<long>(y + h);
 }
-
-
-
-
-
-
-
-
-
-
 
 class ViewProvider : public winrt::implements<ViewProvider, IFrameworkView>
 {
 public:
-	ViewProvider() noexcept :
-		m_exit(false),
-		m_visible(true),
-		m_in_sizemove(false),
-		m_DPI(96.f),
-		m_logicalWidth(1920.f),
-		m_logicalHeight(1080.f),
-		m_nativeOrientation(DisplayOrientations::None),
-		m_currentOrientation(DisplayOrientations::None)
-	{
-	}
+    ViewProvider() noexcept
+        : m_exit(false), m_visible(true), m_in_sizemove(false), m_DPI(96.f), m_logicalWidth(1920.f), m_logicalHeight(1080.f), m_nativeOrientation(DisplayOrientations::None), m_currentOrientation(DisplayOrientations::None)
+    {
+    }
 
-	// IFrameworkView methods
-	void Initialize(CoreApplicationView const& applicationView)
-	{
-		applicationView.Activated({ this, &ViewProvider::OnActivated });
+    // IFrameworkView methods
+    void Initialize(CoreApplicationView const &applicationView)
+    {
+        applicationView.Activated({ this, &ViewProvider::OnActivated });
 
-		CoreApplication::Suspending({ this, &ViewProvider::OnSuspending });
+        CoreApplication::Suspending({ this, &ViewProvider::OnSuspending });
 
-		CoreApplication::Resuming({ this, &ViewProvider::OnResuming });
+        CoreApplication::Resuming({ this, &ViewProvider::OnResuming });
 
-		m_game.emplace();
-	}
+        m_game.emplace();
+    }
 
-	void Uninitialize() noexcept
-	{
-		//m_game.reset();
-	}
+    void Uninitialize() noexcept
+    {
+        // m_game.reset();
+    }
 
-	void SetWindow(CoreWindow const& window)
-	{
-		window.SizeChanged({ this, &ViewProvider::OnWindowSizeChanged });
+    void SetWindow(CoreWindow const &window)
+    {
+        window.SizeChanged({ this, &ViewProvider::OnWindowSizeChanged });
 
-		try
-		{
-			window.ResizeStarted([this](auto&&, auto&&) { m_in_sizemove = true; });
+        try {
+            window.ResizeStarted([this](auto &&, auto &&) { m_in_sizemove = true; });
 
-			window.ResizeCompleted([this](auto&&, auto&&) { m_in_sizemove = false; HandleWindowSizeChanged(); });
-		}
-		catch (...)
-		{
-			// Requires Windows 10 Creators Update (10.0.15063) or later
-		}
+            window.ResizeCompleted([this](auto &&, auto &&) { m_in_sizemove = false; HandleWindowSizeChanged(); });
+        } catch (...) {
+            // Requires Windows 10 Creators Update (10.0.15063) or later
+        }
 
-		window.VisibilityChanged({ this, &ViewProvider::OnVisibilityChanged });
+        window.VisibilityChanged({ this, &ViewProvider::OnVisibilityChanged });
 
-		window.Closed([this](auto&&, auto&&) { m_exit = true; });
+        window.Closed([this](auto &&, auto &&) { m_exit = true; });
 
-		auto dispatcher = CoreWindow::GetForCurrentThread().Dispatcher();
+        auto dispatcher = CoreWindow::GetForCurrentThread().Dispatcher();
 
-		dispatcher.AcceleratorKeyActivated({ this, &ViewProvider::OnAcceleratorKeyActivated });
+        dispatcher.AcceleratorKeyActivated({ this, &ViewProvider::OnAcceleratorKeyActivated });
 
-		auto navigation = SystemNavigationManager::GetForCurrentView();
+        auto navigation = SystemNavigationManager::GetForCurrentView();
 
-		// UWP on Xbox One triggers a back request whenever the B button is pressed
-		// which can result in the app being suspended if unhandled
-		navigation.BackRequested([](const winrt::Windows::Foundation::IInspectable&, const BackRequestedEventArgs& args)
-			{
-				args.Handled(true);
-			});
+        // UWP on Xbox One triggers a back request whenever the B button is pressed
+        // which can result in the app being suspended if unhandled
+        navigation.BackRequested([](const winrt::Windows::Foundation::IInspectable &, const BackRequestedEventArgs &args) {
+            args.Handled(true);
+        });
 
-		auto currentDisplayInformation = DisplayInformation::GetForCurrentView();
+        auto currentDisplayInformation = DisplayInformation::GetForCurrentView();
 
-		currentDisplayInformation.DpiChanged({ this, &ViewProvider::OnDpiChanged });
+        currentDisplayInformation.DpiChanged({ this, &ViewProvider::OnDpiChanged });
 
-		currentDisplayInformation.OrientationChanged({ this, &ViewProvider::OnOrientationChanged });
+        currentDisplayInformation.OrientationChanged({ this, &ViewProvider::OnOrientationChanged });
 
-		DisplayInformation::DisplayContentsInvalidated({ this, &ViewProvider::OnDisplayContentsInvalidated });
+        DisplayInformation::DisplayContentsInvalidated({ this, &ViewProvider::OnDisplayContentsInvalidated });
 
-		m_DPI = currentDisplayInformation.LogicalDpi();
+        m_DPI = currentDisplayInformation.LogicalDpi();
 
-		m_logicalWidth = window.Bounds().Width;
-		m_logicalHeight = window.Bounds().Height;
+        m_logicalWidth = window.Bounds().Width;
+        m_logicalHeight = window.Bounds().Height;
 
-		m_nativeOrientation = currentDisplayInformation.NativeOrientation();
-		m_currentOrientation = currentDisplayInformation.CurrentOrientation();
+        m_nativeOrientation = currentDisplayInformation.NativeOrientation();
+        m_currentOrientation = currentDisplayInformation.CurrentOrientation();
 
-		int outputWidth = ConvertDipsToPixels(m_logicalWidth, m_DPI);
-		int outputHeight = ConvertDipsToPixels(m_logicalHeight, m_DPI);
+        int outputWidth = ConvertDipsToPixels(m_logicalWidth, m_DPI);
+        int outputHeight = ConvertDipsToPixels(m_logicalHeight, m_DPI);
 
-		DXGI_MODE_ROTATION rotation = ComputeDisplayRotation();
+        DXGI_MODE_ROTATION rotation = ComputeDisplayRotation();
 
-		if (rotation == DXGI_MODE_ROTATION_ROTATE90 || rotation == DXGI_MODE_ROTATION_ROTATE270)
-		{
-			std::swap(outputWidth, outputHeight);
-		}
+        if (rotation == DXGI_MODE_ROTATION_ROTATE90 || rotation == DXGI_MODE_ROTATION_ROTATE270) {
+            std::swap(outputWidth, outputHeight);
+        }
 
-		auto windowPtr = static_cast<::IUnknown*>(winrt::get_abi(window));
-		m_game->Initialize(windowPtr, outputWidth, outputHeight); //TODO: Rotate
-	}
+        auto windowPtr = static_cast<::IUnknown *>(winrt::get_abi(window));
+        m_game->Initialize(windowPtr, outputWidth, outputHeight); // TODO: Rotate
+    }
 
-	void Load(winrt::hstring const&) noexcept
-	{
-	}
+    void Load(winrt::hstring const &) noexcept
+    {
+    }
 
-	void Run()
-	{
-		while (!m_exit)
-		{
-			if (m_visible)
-			{
-				m_game->Frame();
+    void Run()
+    {
+        while (!m_exit) {
+            if (m_visible) {
+                m_game->Frame();
 
-				CoreWindow::GetForCurrentThread().Dispatcher().ProcessEvents(CoreProcessEventsOption::ProcessAllIfPresent);
-			}
-			else
-			{
-				CoreWindow::GetForCurrentThread().Dispatcher().ProcessEvents(CoreProcessEventsOption::ProcessOneAndAllPending);
-			}
-		}
-	}
+                CoreWindow::GetForCurrentThread().Dispatcher().ProcessEvents(CoreProcessEventsOption::ProcessAllIfPresent);
+            } else {
+                CoreWindow::GetForCurrentThread().Dispatcher().ProcessEvents(CoreProcessEventsOption::ProcessOneAndAllPending);
+            }
+        }
+    }
 
 protected:
-	// Event handlers
-	void OnActivated(CoreApplicationView const& /*applicationView*/, IActivatedEventArgs const& args)
-	{
-		if (args.Kind() == ActivationKind::Launch)
-		{
-			auto launchArgs = reinterpret_cast<const LaunchActivatedEventArgs*>(&args);
+    // Event handlers
+    void OnActivated(CoreApplicationView const & /*applicationView*/, IActivatedEventArgs const &args)
+    {
+        if (args.Kind() == ActivationKind::Launch) {
+            auto launchArgs = reinterpret_cast<const LaunchActivatedEventArgs *>(&args);
 
-			if (launchArgs->PrelaunchActivated())
-			{
-				// Opt-out of Prelaunch
-				CoreApplication::Exit();
-				return;
-			}
-		}
+            if (launchArgs->PrelaunchActivated()) {
+                // Opt-out of Prelaunch
+                CoreApplication::Exit();
+                return;
+            }
+        }
 
-		int w = 1920, h = 1080;
-		//m_game->GetDefaultSize(w, h);
+        int w = 1920, h = 1080;
+        // m_game->GetDefaultSize(w, h);
 
-		m_DPI = DisplayInformation::GetForCurrentView().LogicalDpi();
+        m_DPI = DisplayInformation::GetForCurrentView().LogicalDpi();
 
-		ApplicationView::PreferredLaunchWindowingMode(ApplicationViewWindowingMode::PreferredLaunchViewSize);
-		// Change to ApplicationViewWindowingMode::FullScreen to default to full screen
+        ApplicationView::PreferredLaunchWindowingMode(ApplicationViewWindowingMode::PreferredLaunchViewSize);
+        // Change to ApplicationViewWindowingMode::FullScreen to default to full screen
 
-		auto desiredSize = Size(ConvertPixelsToDips(w, m_DPI), ConvertPixelsToDips(h, m_DPI));
+        auto desiredSize = Size(ConvertPixelsToDips(w, m_DPI), ConvertPixelsToDips(h, m_DPI));
 
-		ApplicationView::PreferredLaunchViewSize(desiredSize);
+        ApplicationView::PreferredLaunchViewSize(desiredSize);
 
-		auto view = ApplicationView::GetForCurrentView();
+        auto view = ApplicationView::GetForCurrentView();
 
-		auto minSize = Size(ConvertPixelsToDips(320, m_DPI), ConvertPixelsToDips(200, m_DPI));
+        auto minSize = Size(ConvertPixelsToDips(320, m_DPI), ConvertPixelsToDips(200, m_DPI));
 
-		view.SetPreferredMinSize(minSize);
+        view.SetPreferredMinSize(minSize);
 
-		CoreWindow::GetForCurrentThread().Activate();
+        CoreWindow::GetForCurrentThread().Activate();
 
-		view.FullScreenSystemOverlayMode(FullScreenSystemOverlayMode::Minimal);
+        view.FullScreenSystemOverlayMode(FullScreenSystemOverlayMode::Minimal);
 
-		view.TryResizeView(desiredSize);
-	}
+        view.TryResizeView(desiredSize);
+    }
 
-	void OnSuspending(IInspectable const& /*sender*/, SuspendingEventArgs const& args)
-	{
-		auto deferral = args.SuspendingOperation().GetDeferral();
+    void OnSuspending(IInspectable const & /*sender*/, SuspendingEventArgs const &args)
+    {
+        auto deferral = args.SuspendingOperation().GetDeferral();
 
-		auto f = std::async(std::launch::async, [this, deferral]()
-			{
-				//m_game->OnSuspending();
+        auto f = std::async(std::launch::async, [this, deferral]() {
+            // m_game->OnSuspending();
 
-				deferral.Complete();
-			});
-	}
+            deferral.Complete();
+        });
+    }
 
-	void OnResuming(IInspectable const& /*sender*/, IInspectable const& /*args*/)
-	{
-		//m_game->OnResuming();
-	}
+    void OnResuming(IInspectable const & /*sender*/, IInspectable const & /*args*/)
+    {
+        // m_game->OnResuming();
+    }
 
-	void OnWindowSizeChanged(CoreWindow const& sender, WindowSizeChangedEventArgs const& /*args*/)
-	{
-		m_logicalWidth = sender.Bounds().Width;
-		m_logicalHeight = sender.Bounds().Height;
+    void OnWindowSizeChanged(CoreWindow const &sender, WindowSizeChangedEventArgs const & /*args*/)
+    {
+        m_logicalWidth = sender.Bounds().Width;
+        m_logicalHeight = sender.Bounds().Height;
 
-		if (m_in_sizemove)
-			return;
+        if (m_in_sizemove)
+            return;
 
-		HandleWindowSizeChanged();
-	}
+        HandleWindowSizeChanged();
+    }
 
-	void OnVisibilityChanged(CoreWindow const& /*sender*/, VisibilityChangedEventArgs const& args)
-	{
-		m_visible = args.Visible();
-		//if (m_visible)
-		//    m_game->OnActivated();
-		//else
-		//    m_game->OnDeactivated();
-	}
+    void OnVisibilityChanged(CoreWindow const & /*sender*/, VisibilityChangedEventArgs const &args)
+    {
+        m_visible = args.Visible();
+        // if (m_visible)
+        //     m_game->OnActivated();
+        // else
+        //     m_game->OnDeactivated();
+    }
 
-	void OnAcceleratorKeyActivated(CoreDispatcher const&, AcceleratorKeyEventArgs const& args)
-	{
-		if (args.EventType() == CoreAcceleratorKeyEventType::SystemKeyDown
-			&& args.VirtualKey() == VirtualKey::Enter
-			&& args.KeyStatus().IsMenuKeyDown
-			&& !args.KeyStatus().WasKeyDown)
-		{
-			// Implements the classic ALT+ENTER fullscreen toggle
-			auto view = ApplicationView::GetForCurrentView();
+    void OnAcceleratorKeyActivated(CoreDispatcher const &, AcceleratorKeyEventArgs const &args)
+    {
+        if (args.EventType() == CoreAcceleratorKeyEventType::SystemKeyDown && args.VirtualKey() == VirtualKey::Enter && args.KeyStatus().IsMenuKeyDown && !args.KeyStatus().WasKeyDown) {
+            // Implements the classic ALT+ENTER fullscreen toggle
+            auto view = ApplicationView::GetForCurrentView();
 
-			if (view.IsFullScreenMode())
-				view.ExitFullScreenMode();
-			else
-				view.TryEnterFullScreenMode();
+            if (view.IsFullScreenMode())
+                view.ExitFullScreenMode();
+            else
+                view.TryEnterFullScreenMode();
 
-			args.Handled(true);
-		}
-	}
+            args.Handled(true);
+        }
+    }
 
-	void OnDpiChanged(DisplayInformation const& sender, IInspectable const& /*args*/)
-	{
-		m_DPI = sender.LogicalDpi();
+    void OnDpiChanged(DisplayInformation const &sender, IInspectable const & /*args*/)
+    {
+        m_DPI = sender.LogicalDpi();
 
-		HandleWindowSizeChanged();
-	}
+        HandleWindowSizeChanged();
+    }
 
-	void OnOrientationChanged(DisplayInformation const& sender, IInspectable const& /*args*/)
-	{
-		auto resizeManager = CoreWindowResizeManager::GetForCurrentView();
-		resizeManager.ShouldWaitForLayoutCompletion(true);
+    void OnOrientationChanged(DisplayInformation const &sender, IInspectable const & /*args*/)
+    {
+        auto resizeManager = CoreWindowResizeManager::GetForCurrentView();
+        resizeManager.ShouldWaitForLayoutCompletion(true);
 
-		m_currentOrientation = sender.CurrentOrientation();
+        m_currentOrientation = sender.CurrentOrientation();
 
-		HandleWindowSizeChanged();
+        HandleWindowSizeChanged();
 
-		resizeManager.NotifyLayoutCompleted();
-	}
+        resizeManager.NotifyLayoutCompleted();
+    }
 
-	void OnDisplayContentsInvalidated(DisplayInformation const& /*sender*/, IInspectable const& /*args*/)
-	{
-		//m_game->ValidateDevice();
-		//m_game->OnDisplayChange();
-	}
+    void OnDisplayContentsInvalidated(DisplayInformation const & /*sender*/, IInspectable const & /*args*/)
+    {
+        // m_game->ValidateDevice();
+        // m_game->OnDisplayChange();
+    }
 
+    DXGI_MODE_ROTATION ComputeDisplayRotation() const noexcept
+    {
+        DXGI_MODE_ROTATION rotation = DXGI_MODE_ROTATION_UNSPECIFIED;
 
-	DXGI_MODE_ROTATION ComputeDisplayRotation() const noexcept
-	{
-		DXGI_MODE_ROTATION rotation = DXGI_MODE_ROTATION_UNSPECIFIED;
+        switch (m_nativeOrientation) {
+        case DisplayOrientations::Landscape:
+            switch (m_currentOrientation) {
+            case DisplayOrientations::Landscape:
+                rotation = DXGI_MODE_ROTATION_IDENTITY;
+                break;
 
-		switch (m_nativeOrientation)
-		{
-		case DisplayOrientations::Landscape:
-			switch (m_currentOrientation)
-			{
-			case DisplayOrientations::Landscape:
-				rotation = DXGI_MODE_ROTATION_IDENTITY;
-				break;
+            case DisplayOrientations::Portrait:
+                rotation = DXGI_MODE_ROTATION_ROTATE270;
+                break;
 
-			case DisplayOrientations::Portrait:
-				rotation = DXGI_MODE_ROTATION_ROTATE270;
-				break;
+            case DisplayOrientations::LandscapeFlipped:
+                rotation = DXGI_MODE_ROTATION_ROTATE180;
+                break;
 
-			case DisplayOrientations::LandscapeFlipped:
-				rotation = DXGI_MODE_ROTATION_ROTATE180;
-				break;
+            case DisplayOrientations::PortraitFlipped:
+                rotation = DXGI_MODE_ROTATION_ROTATE90;
+                break;
 
-			case DisplayOrientations::PortraitFlipped:
-				rotation = DXGI_MODE_ROTATION_ROTATE90;
-				break;
+            default:
+                break;
+            }
+            break;
 
-			default:
-				break;
-			}
-			break;
+        case DisplayOrientations::Portrait:
+            switch (m_currentOrientation) {
+            case DisplayOrientations::Landscape:
+                rotation = DXGI_MODE_ROTATION_ROTATE90;
+                break;
 
-		case DisplayOrientations::Portrait:
-			switch (m_currentOrientation)
-			{
-			case DisplayOrientations::Landscape:
-				rotation = DXGI_MODE_ROTATION_ROTATE90;
-				break;
+            case DisplayOrientations::Portrait:
+                rotation = DXGI_MODE_ROTATION_IDENTITY;
+                break;
 
-			case DisplayOrientations::Portrait:
-				rotation = DXGI_MODE_ROTATION_IDENTITY;
-				break;
+            case DisplayOrientations::LandscapeFlipped:
+                rotation = DXGI_MODE_ROTATION_ROTATE270;
+                break;
 
-			case DisplayOrientations::LandscapeFlipped:
-				rotation = DXGI_MODE_ROTATION_ROTATE270;
-				break;
+            case DisplayOrientations::PortraitFlipped:
+                rotation = DXGI_MODE_ROTATION_ROTATE180;
+                break;
 
-			case DisplayOrientations::PortraitFlipped:
-				rotation = DXGI_MODE_ROTATION_ROTATE180;
-				break;
+            default:
+                break;
+            }
+            break;
 
-			default:
-				break;
-			}
-			break;
+        default:
+            break;
+        }
 
-		default:
-			break;
-		}
+        return rotation;
+    }
 
-		return rotation;
-	}
+    void HandleWindowSizeChanged()
+    {
+        int outputWidth = ConvertDipsToPixels(m_logicalWidth, m_DPI);
+        int outputHeight = ConvertDipsToPixels(m_logicalHeight, m_DPI);
 
-	void HandleWindowSizeChanged()
-	{
-		int outputWidth = ConvertDipsToPixels(m_logicalWidth, m_DPI);
-		int outputHeight = ConvertDipsToPixels(m_logicalHeight, m_DPI);
+        DXGI_MODE_ROTATION rotation = ComputeDisplayRotation();
 
-		DXGI_MODE_ROTATION rotation = ComputeDisplayRotation();
+        if (rotation == DXGI_MODE_ROTATION_ROTATE90 || rotation == DXGI_MODE_ROTATION_ROTATE270) {
+            std::swap(outputWidth, outputHeight);
+        }
 
-		if (rotation == DXGI_MODE_ROTATION_ROTATE90 || rotation == DXGI_MODE_ROTATION_ROTATE270)
-		{
-			std::swap(outputWidth, outputHeight);
-		}
-
-		//m_game->OnWindowSizeChanged(outputWidth, outputHeight, rotation);
-	}
+        // m_game->OnWindowSizeChanged(outputWidth, outputHeight, rotation);
+    }
 
 private:
-	bool                    m_exit;
-	bool                    m_visible;
-	bool                    m_in_sizemove;
-	float                   m_DPI;
-	float                   m_logicalWidth;
-	float                   m_logicalHeight;
-	std::optional<Test::App>   m_game;
+    bool m_exit;
+    bool m_visible;
+    bool m_in_sizemove;
+    float m_DPI;
+    float m_logicalWidth;
+    float m_logicalHeight;
+    std::optional<Test::App> m_game;
 
-	winrt::Windows::Graphics::Display::DisplayOrientations	m_nativeOrientation;
-	winrt::Windows::Graphics::Display::DisplayOrientations	m_currentOrientation;
+    winrt::Windows::Graphics::Display::DisplayOrientations m_nativeOrientation;
+    winrt::Windows::Graphics::Display::DisplayOrientations m_currentOrientation;
 };
-
 
 class ViewProviderFactory : public winrt::implements<ViewProviderFactory, IFrameworkViewSource>
 {
 public:
-	IFrameworkView CreateView()
-	{
-		return winrt::make<ViewProvider>();
-	}
+    IFrameworkView CreateView()
+    {
+        return winrt::make<ViewProvider>();
+    }
 };
-
-

--- a/examples/uniform-buffers-kdgui/app.cpp
+++ b/examples/uniform-buffers-kdgui/app.cpp
@@ -78,7 +78,6 @@ Test::App::App(uint32_t width, uint32_t height)
     constant_buffer.UpdateSubresource(RawView(buffer));
     mapped_buffer = constant_buffer.MapMemory();
 
-
     std::array<wis::BindingDescriptor, 1> bindings{
         wis::BindingDescriptor{
                 .binding = 0,
@@ -145,7 +144,7 @@ void Test::App::Frame()
     auto back = swap.GetBackBuffer();
 
     buffer.offset.x += 0.0005f;
-    float* mapped = reinterpret_cast<float*>(mapped_buffer.data());
+    float *mapped = reinterpret_cast<float *>(mapped_buffer.data());
     mapped[0] = buffer.offset.x;
 
     context.TextureBarrier({ .state_before = wis::TextureState::Present,
@@ -167,7 +166,7 @@ void Test::App::Frame()
     context.IASetPrimitiveTopology(wis::PrimitiveTopology::trianglelist);
     context.IASetVertexBuffers({ &vb, 1 });
 
-    context.BeginRenderPass(render_pass, { rtvsx.data(), swap.StereoSupported() + 1u });
+    context.BeginRenderPass(render_pass, { rtvsx.data(), static_cast<unsigned int>(swap.StereoSupported()) + 1u });
     context.DrawInstanced(3);
     context.EndRenderPass();
 
@@ -194,7 +193,6 @@ void Test::App::WaitForGPU()
     fence.Wait(vfence);
 }
 
-
 void Test::App::OnResize(uint32_t width, uint32_t height)
 {
     if (!swap.Resize(width, height))
@@ -210,7 +208,7 @@ void Test::App::OnResize(uint32_t width, uint32_t height)
     };
 
     // needs to be recreated for vulkan for now
-    render_pass = device.CreateRenderPass({ width, height }, { cas2.data(), swap.StereoSupported() + 1u });
+    render_pass = device.CreateRenderPass({ width, height }, { cas2.data(), static_cast<unsigned int>(swap.StereoSupported()) + 1u });
 
     // needs to be recreated for vulkan for now
     static constexpr std::array<wis::InputLayoutDesc, 2> ia{
@@ -222,7 +220,7 @@ void Test::App::OnResize(uint32_t width, uint32_t height)
     desc.SetVS(vs);
     desc.SetPS(ps);
     desc.SetRenderPass(render_pass);
-    pipeline = device.CreateGraphicsPipeline(std::move(desc), ia);
+    pipeline = device.CreateGraphicsPipeline(desc, ia);
     context.SetPipeline(pipeline);
 
     auto x = swap.GetRenderTargets();

--- a/examples/uniform-buffers-kdgui/app.h
+++ b/examples/uniform-buffers-kdgui/app.h
@@ -19,7 +19,6 @@ private:
     void WaitForGPU();
     void OnResize(uint32_t width, uint32_t height);
 
-private:
     XApp app;
     Window wnd;
 
@@ -50,7 +49,6 @@ private:
     wis::RenderPass render_pass;
     uint64_t fence_value = 1;
 
-private:
     struct SceneConstantBuffer {
         glm::vec4 offset;
         float padding[60]; // Padding so the constant buffer is 256-byte aligned.

--- a/examples/uniform-buffers-kdgui/window.cpp
+++ b/examples/uniform-buffers-kdgui/window.cpp
@@ -42,8 +42,8 @@ public:
 Window::Window(uint32_t width, uint32_t height, WindowP *p)
     : p(p)
 {
-    p->width = 1920;
-    p->height = 1080;
+    p->width = width;
+    p->height = height;
     p->visible = true;
 }
 Window::~Window()
@@ -75,7 +75,7 @@ wis::SurfaceParameters Window::GetSurfaceOptions() const noexcept
     if (KDGui::LinuxWaylandPlatformIntegration::checkAvailable()) {
         auto *platformIntegration = KDGui::GuiApplication::instance()->guiPlatformIntegration();
         auto *waylandPlatformIntegration = dynamic_cast<KDGui::LinuxWaylandPlatformIntegration *>(platformIntegration);
-        auto waylandWindow = dynamic_cast<KDGui::LinuxWaylandPlatformWindow *>(p->platformWindow());
+        auto *waylandWindow = dynamic_cast<KDGui::LinuxWaylandPlatformWindow *>(p->platformWindow());
         return wis::SurfaceParameters{
             waylandPlatformIntegration->display(),
             waylandWindow->surface(),

--- a/examples/uniform-buffers-kdgui/window.h
+++ b/examples/uniform-buffers-kdgui/window.h
@@ -23,12 +23,11 @@ private:
 public:
     ~Window();
 
-public:
-    bool visible() const noexcept;
-    uint32_t width() const noexcept;
-    uint32_t height() const noexcept;
-    wis::SurfaceParameters GetSurfaceOptions() const noexcept;
-    bool resized() const noexcept;
+    [[nodiscard]] bool visible() const noexcept;
+    [[nodiscard]] uint32_t width() const noexcept;
+    [[nodiscard]] uint32_t height() const noexcept;
+    [[nodiscard]] wis::SurfaceParameters GetSurfaceOptions() const noexcept;
+    [[nodiscard]] bool resized() const noexcept;
     // KDGpu::Surface createSurface(KDGpu::Instance& instance);
 private:
     WindowP *p;
@@ -41,7 +40,6 @@ public:
     XApp();
     ~XApp();
 
-public:
     void ProcessEvents();
     Window createWindow(uint32_t width, uint32_t height);
 

--- a/wisdom/include/wisdom/api/api_adapter.h
+++ b/wisdom/include/wisdom/api/api_adapter.h
@@ -4,65 +4,59 @@
 #include <wisdom/bridge/format.h>
 #endif // !WISDOM_MODULES
 
-
-
 WIS_EXPORT namespace wis
 {
-	/// @brief Adapter flags used to describe the adapter properties
-	enum class AdapterFlags : uint32_t
-	{
-		None = 0, //< Adapter is a hardware adapter
-		Remote = 1, //< Adapter is a remote adapter
-		Software = 2, //< Adapter is a software adapter
-		ACGCompatible = 4, //< Adapter is Active Code Guard compatible (DX 12.1 only)
+    /// @brief Adapter flags used to describe the adapter properties
+    enum class AdapterFlags : uint32_t {
+        None = 0, //< Adapter is a hardware adapter
+        Remote = 1, //< Adapter is a remote adapter
+        Software = 2, //< Adapter is a software adapter
+        ACGCompatible = 4, //< Adapter is Active Code Guard compatible (DX 12.1 only)
 
-		// unused 
-		SUPPORT_MONITORED_FENCES = 8,  //< Adapter supports monitored fences (DX 12.1)
-		SUPPORT_NON_MONITORED_FENCES = 0x10, //< Adapter supports non-monitored fences (DX 12.1)
-		KEYED_MUTEX_CONFORMANCE = 0x20, //< Adapter supports KeyedMutex (DX 12.1)
-	};
+        // unused
+        SUPPORT_MONITORED_FENCES = 8, //< Adapter supports monitored fences (DX 12.1)
+        SUPPORT_NON_MONITORED_FENCES = 0x10, //< Adapter supports non-monitored fences (DX 12.1)
+        KEYED_MUTEX_CONFORMANCE = 0x20, //< Adapter supports KeyedMutex (DX 12.1)
+    };
 
+    /// @brief Adapter description, contains information about the adapter capabilities
+    struct AdapterDesc {
+        /// @brief Checks if the adapter is a software adapter
+        /// @return true if the adapter is a software adapter
+        [[nodiscard]] bool IsSoftware() const noexcept
+        {
+            using namespace river::flags;
+            return (flags & AdapterFlags::Software) != 0u;
+        }
 
-	/// @brief Adapter description, contains information about the adapter capabilities
-	struct AdapterDesc
-	{
-	public:
-		/// @brief Checks if the adapter is a software adapter
-		/// @return true if the adapter is a software adapter
-		bool IsSoftware()const noexcept{
-			using namespace river::flags;
-			return flags & AdapterFlags::Software;
-		}
+        /// @brief Outputs a string representation of the adapter properties
+        /// @return String representation of the adapter properties
+        [[nodiscard]] std::string to_string() const noexcept
+        {
+            return wis::format(
+                    "[description]: {}\n"
+                    "[vendor id]: 0x{:X}\n"
+                    "[device id]: 0x{:X}\n"
+                    "[subsys id]: 0x{:X}\n"
+                    "[revision]: {}\n"
+                    "[dedicated video memory]: {}\n"
+                    "[dedicated system memory]: {}\n"
+                    "[shared system memory]: {}\n"
+                    "[adapter id]: {:X}\n",
+                    description, vendor_id, device_id, subsys_id, revision, dedicated_video_memory, dedicated_system_memory, shared_system_memory, adapter_id);
+        }
 
-		/// @brief Outputs a string representation of the adapter properties
-		/// @return String representation of the adapter properties
-		std::string to_string()const noexcept
-		{
-			return wis::format(
-				"[description]: {}\n"
-				"[vendor id]: 0x{:X}\n"
-				"[device id]: 0x{:X}\n"
-				"[subsys id]: 0x{:X}\n"
-				"[revision]: {}\n"
-				"[dedicated video memory]: {}\n"
-				"[dedicated system memory]: {}\n"
-				"[shared system memory]: {}\n"
-				"[adapter id]: {:X}\n",
-				description, vendor_id, device_id, subsys_id, revision, dedicated_video_memory, dedicated_system_memory, shared_system_memory, adapter_id
-			);
-		}
-	public:
-		std::string description; //< Adapter description
-		uint32_t vendor_id; //< Adapter vendor id
-		uint32_t device_id; //< Adapter device id
-		uint32_t subsys_id; //< Adapter subsystem id (DX12)/ api version (Vulkan)
-		uint32_t revision; //< Adapter revision (DX12)/ driver version (Vulkan)
+        std::string description; //< Adapter description
+        uint32_t vendor_id; //< Adapter vendor id
+        uint32_t device_id; //< Adapter device id
+        uint32_t subsys_id; //< Adapter subsystem id (DX12)/ api version (Vulkan)
+        uint32_t revision; //< Adapter revision (DX12)/ driver version (Vulkan)
 
-		size_t dedicated_video_memory; //< Dedicated video memory
-		size_t dedicated_system_memory; //< Dedicated system memory (DX12 only)
-		size_t shared_system_memory; //< Shared system memory
-		uint64_t adapter_id; //< Adapter id(LUID)
+        size_t dedicated_video_memory; //< Dedicated video memory
+        size_t dedicated_system_memory; //< Dedicated system memory (DX12 only)
+        size_t shared_system_memory; //< Shared system memory
+        uint64_t adapter_id; //< Adapter id(LUID)
 
-		AdapterFlags flags = AdapterFlags::None; //< Adapter flags describing the adapter properties
-	};
+        AdapterFlags flags = AdapterFlags::None; //< Adapter flags describing the adapter properties
+    };
 }

--- a/wisdom/include/wisdom/api/api_barrier.h
+++ b/wisdom/include/wisdom/api/api_barrier.h
@@ -5,70 +5,65 @@
 
 WIS_EXPORT namespace wis
 {
-	/// @brief Texture state layout
-	enum class TextureState : uint32_t
-	{
-		Undefined = 0xffffffff, //VK_IMAGE_LAYOUT_UNDEFINED 
-		Common = 0,//VK_IMAGE_LAYOUT_GENERAL 
-		Read = 1,//VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL 
-		RenderTarget = 2, // VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL
-		DepthWrite = 4, //VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL 
-		DepthRead = 5, //VK_IMAGE_LAYOUT_DEPTH_STENCIL_READ_ONLY_OPTIMAL 
-		ShaderResource = 6, //VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL 
-		CopySrc = 7, //VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL 
-		CopyDst = 8, //VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL
-		VRSSource = 11, //VK_IMAGE_LAYOUT_FRAGMENT_SHADING_RATE_ATTACHMENT_OPTIMAL_KHR 
-		VideoDecodeRead = 12, //VK_IMAGE_LAYOUT_VIDEO_DECODE_SRC_KHR
-		VideoDecodeWrite = 13, //VK_IMAGE_LAYOUT_VIDEO_DECODE_DST_KHR 
-		VideoEncodeRead = 16, //VK_IMAGE_LAYOUT_VIDEO_ENCODE_SRC_KHR 
-		VideoEncodeWrite = 17, //VK_IMAGE_LAYOUT_VIDEO_ENCODE_DST_KHR 
-		Present = 100,//VK_IMAGE_LAYOUT_PRESENT_SRC_KHR 
-	};
+    /// @brief Texture state layout
+    enum class TextureState : uint32_t {
+        Undefined = 0xffffffff, // VK_IMAGE_LAYOUT_UNDEFINED
+        Common = 0, // VK_IMAGE_LAYOUT_GENERAL
+        Read = 1, // VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL
+        RenderTarget = 2, // VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL
+        DepthWrite = 4, // VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL
+        DepthRead = 5, // VK_IMAGE_LAYOUT_DEPTH_STENCIL_READ_ONLY_OPTIMAL
+        ShaderResource = 6, // VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL
+        CopySrc = 7, // VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL
+        CopyDst = 8, // VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL
+        VRSSource = 11, // VK_IMAGE_LAYOUT_FRAGMENT_SHADING_RATE_ATTACHMENT_OPTIMAL_KHR
+        VideoDecodeRead = 12, // VK_IMAGE_LAYOUT_VIDEO_DECODE_SRC_KHR
+        VideoDecodeWrite = 13, // VK_IMAGE_LAYOUT_VIDEO_DECODE_DST_KHR
+        VideoEncodeRead = 16, // VK_IMAGE_LAYOUT_VIDEO_ENCODE_SRC_KHR
+        VideoEncodeWrite = 17, // VK_IMAGE_LAYOUT_VIDEO_ENCODE_DST_KHR
+        Present = 100, // VK_IMAGE_LAYOUT_PRESENT_SRC_KHR
+    };
 
-	/// @brief Resource access layout
-	enum class ResourceAccess : uint32_t
-	{
-		Common = 0, //VK_ACCESS_MEMORY_READ_BIT | VK_ACCESS_MEMORY_WRITE_BIT 
-		VertexBuffer = 0x1, //VK_ACCESS_VERTEX_ATTRIBUTE_READ_BIT 
-		ConstantBuffer = 0x2, //VK_ACCESS_UNIFORM_READ_BIT 
-		IndexBuffer = 0x4,	//VK_ACCESS_INDEX_READ_BIT 
-		RenderTarget = 0x8, //VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT 
-		UnorderedAccess = 0x10, //VK_ACCESS_SHADER_WRITE_BIT | VK_ACCESS_SHADER_READ_BIT 
-		DepthWrite = 0x20, //VK_ACCESS_DEPTH_STENCIL_ATTACHMENT_WRITE_BIT 
-		DepthRead = 0x40, //VK_ACCESS_DEPTH_STENCIL_ATTACHMENT_READ_BIT 
-		ShaderResource = 0x80,//VK_ACCESS_SHADER_READ_BIT
-		TransformFeedback = 0x100, //VK_ACCESS_TRANSFORM_FEEDBACK_WRITE_BIT_EXT
-		IndirectCommandRead = 0x200,//VK_ACCESS_INDIRECT_COMMAND_READ_BIT 
-		CopySource = 0x400, //VK_ACCESS_TRANSFER_READ_BIT 
-		CopyDest = 0x800,//VK_ACCESS_TRANSFER_WRITE_BIT
-		RayTracingRead = 0x4000,//VK_ACCESS_ACCELERATION_STRUCTURE_READ_BIT_KHR  
-		RayTracingWrite = 0x8000,//VK_ACCESS_ACCELERATION_STRUCTURE_WRITE_BIT_KHR 
-		VRSSource = 0x10000, //VK_ACCESS_FRAGMENT_SHADING_RATE_ATTACHMENT_READ_BIT_KHR 
-		NoAccess = 0x80000000 //VK_ACCESS_NONE
-	};
+    /// @brief Resource access layout
+    enum class ResourceAccess : uint32_t {
+        Common = 0, // VK_ACCESS_MEMORY_READ_BIT | VK_ACCESS_MEMORY_WRITE_BIT
+        VertexBuffer = 0x1, // VK_ACCESS_VERTEX_ATTRIBUTE_READ_BIT
+        ConstantBuffer = 0x2, // VK_ACCESS_UNIFORM_READ_BIT
+        IndexBuffer = 0x4, // VK_ACCESS_INDEX_READ_BIT
+        RenderTarget = 0x8, // VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT
+        UnorderedAccess = 0x10, // VK_ACCESS_SHADER_WRITE_BIT | VK_ACCESS_SHADER_READ_BIT
+        DepthWrite = 0x20, // VK_ACCESS_DEPTH_STENCIL_ATTACHMENT_WRITE_BIT
+        DepthRead = 0x40, // VK_ACCESS_DEPTH_STENCIL_ATTACHMENT_READ_BIT
+        ShaderResource = 0x80, // VK_ACCESS_SHADER_READ_BIT
+        TransformFeedback = 0x100, // VK_ACCESS_TRANSFORM_FEEDBACK_WRITE_BIT_EXT
+        IndirectCommandRead = 0x200, // VK_ACCESS_INDIRECT_COMMAND_READ_BIT
+        CopySource = 0x400, // VK_ACCESS_TRANSFER_READ_BIT
+        CopyDest = 0x800, // VK_ACCESS_TRANSFER_WRITE_BIT
+        RayTracingRead = 0x4000, // VK_ACCESS_ACCELERATION_STRUCTURE_READ_BIT_KHR
+        RayTracingWrite = 0x8000, // VK_ACCESS_ACCELERATION_STRUCTURE_WRITE_BIT_KHR
+        VRSSource = 0x10000, // VK_ACCESS_FRAGMENT_SHADING_RATE_ATTACHMENT_READ_BIT_KHR
+        NoAccess = 0x80000000 // VK_ACCESS_NONE
+    };
 
-	/// @brief Buffer usage flags, TODO: add more
-	enum class BufferFlags : uint32_t
-	{
-		None = 0,
-		ConstantBuffer = 0x10, //VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT
-		VertexBuffer = 0x80, //VK_BUFFER_USAGE_VERTEX_BUFFER_BIT
-	};
+    /// @brief Buffer usage flags, TODO: add more
+    enum class BufferFlags : uint32_t {
+        None = 0,
+        ConstantBuffer = 0x10, // VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT
+        VertexBuffer = 0x80, // VK_BUFFER_USAGE_VERTEX_BUFFER_BIT
+    };
 
-	/// @brief Basic texture barrier w/o synchronization
-	struct TextureBarrier
-	{
-		TextureState state_before; //< State before the barrier
-		TextureState state_after; //< State after the barrier
-		ResourceAccess access_before; //< Access before the barrier
-		ResourceAccess access_after; //< Access after the barrier
-		SubresourceRange range{}; //< Subresource range to apply the barrier to
-	};
+    /// @brief Basic texture barrier w/o synchronization
+    struct TextureBarrier {
+        TextureState state_before; //< State before the barrier
+        TextureState state_after; //< State after the barrier
+        ResourceAccess access_before; //< Access before the barrier
+        ResourceAccess access_after; //< Access after the barrier
+        SubresourceRange range{}; //< Subresource range to apply the barrier to
+    };
 
-	/// @brief Basic buffer barrier w/o synchronization
-	struct BufferBarrier
-	{
-		ResourceAccess access_before; //< Access before the barrier
-		ResourceAccess access_after; //< Access after the barrier
-	};
+    /// @brief Basic buffer barrier w/o synchronization
+    struct BufferBarrier {
+        ResourceAccess access_before; //< Access before the barrier
+        ResourceAccess access_after; //< Access after the barrier
+    };
 }

--- a/wisdom/include/wisdom/api/api_common.h
+++ b/wisdom/include/wisdom/api/api_common.h
@@ -275,7 +275,6 @@ WIS_EXPORT namespace wis
 
     /// @brief Basic Viewport structure
     struct Viewport {
-    public:
         /// @brief Create a viewport with the given width, height and depth range
         /// @param width Width of the viewport
         /// @param height Height of the viewport
@@ -286,7 +285,6 @@ WIS_EXPORT namespace wis
         Viewport(float width, float height, float min_depth = 0.0f, float max_depth = 1.0f, float top_leftx = 0.0f, float top_lefty = 0.0f)
             : top_leftx(top_leftx), top_lefty(top_lefty), width(width), height(height), min_depth(min_depth), max_depth(max_depth) { }
 
-    public:
         float top_leftx;
         float top_lefty;
         float width;
@@ -298,7 +296,6 @@ WIS_EXPORT namespace wis
     /// @brief Basic Rect structure for scissor rects
     /// @note  The order of the members is important, do not change it or the structure will not match the D3D12 structure
     struct ScissorRect {
-    public:
         /// @brief Create a scissor rect with the given width and height and top left corner at top,left
         /// @param right Right coordinate of the scissor rect
         /// @param bottom Bottom coordinate of the scissor rect
@@ -307,7 +304,6 @@ WIS_EXPORT namespace wis
         ScissorRect(long right, long bottom, long left = 0, long top = 0)
             : left(left), top(top), right(right), bottom(bottom) { }
 
-    public:
         long left;
         long top;
         long right;
@@ -374,12 +370,10 @@ WIS_EXPORT namespace wis
             none = 0,
         };
 
-    public:
         QueueOptions() = default;
         QueueOptions(QueueType type, Priority priority = Priority::normal, Flags flags = Flags::none, uint32_t node_mask = 0)
             : type(type), priority(priority), flags(flags), node_mask(node_mask) { }
 
-    public:
         QueueType type = QueueType::direct; //< Type of the queue (not all types are supported on all backends)
         Priority priority = Priority::normal; //< Priority of the queue (D3D12 only, but changes Vulkan queue search algorithm)
         Flags flags = Flags::none; //< Flags for the queue creation (unused)
@@ -391,7 +385,6 @@ WIS_EXPORT namespace wis
         /// @brief Denotes the whole dimension of the texture (all mips, all layers)
         static constexpr inline uint32_t whole = ~0u;
 
-    public:
         /// @brief Creates a full texture subresource range
         SubresourceRange() = default;
 
@@ -411,7 +404,6 @@ WIS_EXPORT namespace wis
             : base_mip(base_mip), extent_mips(extent_mips) { }
 
         // TODO: Is there mipped array textures?
-    public:
         uint32_t base_mip = 0;
         uint32_t extent_mips = whole;
         uint32_t base_layer = 0;
@@ -447,7 +439,7 @@ WIS_EXPORT namespace wis
     };
 
     enum class BindingType {
-        SRV	= 0,
+        SRV = 0,
         UAV,
         CBV,
         SAMPLER,

--- a/wisdom/include/wisdom/api/api_factory.h
+++ b/wisdom/include/wisdom/api/api_factory.h
@@ -5,27 +5,24 @@
 
 WIS_EXPORT namespace wis
 {
-	/// @brief Enumeration specifying Adapter query ordering
-	enum class AdapterPreference
-	{
-		None, //< Default order (defined by system)
-		MinConsumption, //< Order:Integrated, Discrete
-		Performance //< Order: Discrete, Integrated
-	};
+    /// @brief Enumeration specifying Adapter query ordering
+    enum class AdapterPreference {
+        None, //< Default order (defined by system)
+        MinConsumption, //< Order:Integrated, Discrete
+        Performance //< Order: Discrete, Integrated
+    };
 
-	/// @brief Application info, used only for debug purposes in Vulkan
-	struct ApplicationInfo
-	{
-	public:
-		struct Version {
-			uint32_t major{1};
-			uint32_t minor{0};
-			uint32_t patch{0};
-		};
-	public:
-		const char* application_name = "";
-		const char* engine_name = "";
-		Version app_version{};
-		Version engine_version{};
-	};
+    /// @brief Application info, used only for debug purposes in Vulkan
+    struct ApplicationInfo {
+        struct Version {
+            uint32_t major{ 1 };
+            uint32_t minor{ 0 };
+            uint32_t patch{ 0 };
+        };
+
+        const char *application_name = "";
+        const char *engine_name = "";
+        Version app_version{};
+        Version engine_version{};
+    };
 }

--- a/wisdom/include/wisdom/api/api_input_layout.h
+++ b/wisdom/include/wisdom/api/api_input_layout.h
@@ -5,23 +5,21 @@
 
 WIS_EXPORT namespace wis
 {
-	/// @brief Input type for input assembler
-	enum class InputClassification
-	{
-		vertex, //< Per-vertex input
-		instance //< Per-instance input
-	};
+    /// @brief Input type for input assembler
+    enum class InputClassification {
+        vertex, //< Per-vertex input
+        instance //< Per-instance input
+    };
 
-	/// @brief Data format for input assembler
-	struct InputLayoutDesc
-	{
-		uint32_t location; //< Location of the input in the shader
-		const char* semantic_name; //< Semantic name of the input in the shader (e.g. "POSITION")
-		uint32_t semantic_index = 0u; //< Semantic index of the input in the shader (e.g. 0 for "POSITION0")
-		DataFormat format; //< Data format of the input in the shader (e.g. r32g32b32a32_float for float4)
-		uint32_t input_slot = 0u; //< Input slot in the input assembler
-		uint32_t aligned_byte_offset; //< Offset in bytes from the start of the input slot
-		InputClassification input_slot_class = InputClassification::vertex; //< Input type
-		uint32_t instance_data_step_rate = 0u; //< Step rate for per-instance input (ignored for per-vertex input)
-	};
+    /// @brief Data format for input assembler
+    struct InputLayoutDesc {
+        uint32_t location; //< Location of the input in the shader
+        const char *semantic_name; //< Semantic name of the input in the shader (e.g. "POSITION")
+        uint32_t semantic_index = 0u; //< Semantic index of the input in the shader (e.g. 0 for "POSITION0")
+        DataFormat format; //< Data format of the input in the shader (e.g. r32g32b32a32_float for float4)
+        uint32_t input_slot = 0u; //< Input slot in the input assembler
+        uint32_t aligned_byte_offset; //< Offset in bytes from the start of the input slot
+        InputClassification input_slot_class = InputClassification::vertex; //< Input type
+        uint32_t instance_data_step_rate = 0u; //< Step rate for per-instance input (ignored for per-vertex input)
+    };
 }

--- a/wisdom/include/wisdom/api/api_internal.h
+++ b/wisdom/include/wisdom/api/api_internal.h
@@ -2,28 +2,27 @@
 
 WIS_EXPORT namespace wis
 {
-	/// @brief Template class for internal implementation
-	/// @tparam Impl Implementation class type
-	template<class Impl>
-	class Internal
-	{};
+    /// @brief Template class for internal implementation
+    /// @tparam Impl Implementation class type
+    template<class Impl>
+    class Internal
+    {
+    };
 
+    /// @brief QueryInternal class for querying the internal implementation
+    /// @tparam Impl Implementation class type, passed to Internal
+    template<class Impl>
+    class QueryInternal : protected Internal<Impl>
+    {
+    public:
+        using base = QueryInternal<Impl>;
+        using Internal<Impl>::Internal;
 
-	/// @brief QueryInternal class for querying the internal implementation 
-	/// @tparam Impl Implementation class type, passed to Internal
-	template<class Impl>
-	class QueryInternal : protected Internal<Impl>
-	{
-	public:
-		using base = QueryInternal<Impl>;
-		using Internal<Impl>::Internal;
-	public:
-		/// @brief Get the immutable internal implementation
-		/// @return Const reference to the internal implementation
-		[[nodiscard]] 
-		const Internal<Impl>& GetInternal()const
-		{
-			return *this;
-		}
-	};
+        /// @brief Get the immutable internal implementation
+        /// @return Const reference to the internal implementation
+        [[nodiscard]] const Internal<Impl> &GetInternal() const
+        {
+            return *this;
+        }
+    };
 }

--- a/wisdom/include/wisdom/api/api_render_pass.h
+++ b/wisdom/include/wisdom/api/api_render_pass.h
@@ -6,45 +6,37 @@
 // TODO: Refactor
 WIS_EXPORT namespace wis
 {
-	enum class PassLoadOperation : uint8_t
-	{
-		load,
-		clear,
-		discard
-	};
-	enum class PassStoreOperation : uint8_t
-	{
-		store,
-		discard
-	};
-	enum class SampleCount
-	{
-		s1 = 1,
-		s2 = 2,
-		s4 = 4,
-		s8 = 8,
-		s16= 16,
-		s32= 32,
-		s64= 64,
-	};
+    enum class PassLoadOperation : uint8_t {
+        load,
+        clear,
+        discard
+    };
+    enum class PassStoreOperation : uint8_t {
+        store,
+        discard
+    };
+    enum class SampleCount {
+        s1 = 1,
+        s2 = 2,
+        s4 = 4,
+        s8 = 8,
+        s16 = 16,
+        s32 = 32,
+        s64 = 64,
+    };
 
+    struct ColorAttachment {
+        DataFormat format = DataFormat::unknown;
+        PassLoadOperation load = PassLoadOperation::load;
+        PassStoreOperation store = PassStoreOperation::store;
+        uint32_t array_levels = 1;
+    };
 
-	struct ColorAttachment
-	{
-		DataFormat format = DataFormat::unknown;
-		PassLoadOperation load = PassLoadOperation::load;
-		PassStoreOperation store = PassStoreOperation::store;
-		uint32_t array_levels = 1;
-	};
-
-	struct DepthStencilAttachment
-	{
-		DataFormat format = DataFormat::unknown;
-		PassLoadOperation depth_load = PassLoadOperation::load;
-		PassStoreOperation depth_store = PassStoreOperation::store;
-		PassLoadOperation stencil_load = PassLoadOperation::load;
-		PassStoreOperation stencil_store = PassStoreOperation::store;
-	};
-
-	
+    struct DepthStencilAttachment {
+        DataFormat format = DataFormat::unknown;
+        PassLoadOperation depth_load = PassLoadOperation::load;
+        PassStoreOperation depth_store = PassStoreOperation::store;
+        PassLoadOperation stencil_load = PassLoadOperation::load;
+        PassStoreOperation stencil_store = PassStoreOperation::store;
+    };
 }

--- a/wisdom/include/wisdom/api/api_shader.h
+++ b/wisdom/include/wisdom/api/api_shader.h
@@ -2,95 +2,89 @@
 #include <memory>
 #include <span>
 
-
 WIS_EXPORT namespace wis
 {
-	/// @brief Shader intermediate language
-	enum class ShaderLang
-	{
-		dxil,
-		spirv
-	};
+    /// @brief Shader intermediate language
+    enum class ShaderLang {
+        dxil,
+        spirv
+    };
 
-	/// @brief Type of shader
-	enum class ShaderType
-	{
-		unknown,
-		vertex,
-		pixel,
-		geometry,
-		hull,
-		domain,
-		amplification,
-		mesh,
-		compute
-	};
+    /// @brief Type of shader
+    enum class ShaderType {
+        unknown,
+        vertex,
+        pixel,
+        geometry,
+        hull,
+        domain,
+        amplification,
+        mesh,
+        compute
+    };
 
-	/// @brief Compiled shader blob
-	struct shared_blob
-	{
-	public:
-		shared_blob() = default;
+    /// @brief Compiled shader blob
+    struct shared_blob {
+        shared_blob() = default;
 
-		/// @brief Create a blob with the given size
-		/// @param size Size in bytes to allocate
-		shared_blob(size_t size)
-		{
-			allocate(size);
-		}
+        /// @brief Create a blob with the given size
+        /// @param size Size in bytes to allocate
+        shared_blob(size_t size)
+        {
+            allocate(size);
+        }
 
-	public:
+        /// @brief Allocate a blob with the given size
+        /// @param size Size in bytes to allocate
+        void allocate(size_t size)
+        {
+            this->xsize = size;
+            xdata = std::make_shared_for_overwrite<std::byte[]>(size);
+        }
 
-		/// @brief Allocate a blob with the given size
-		/// @param size Size in bytes to allocate
-		void allocate(size_t size)
-		{
-			this->xsize = size;
-			xdata = std::make_shared_for_overwrite<std::byte[]>(size);
-		}
+        /// @brief Get a pointer to the data of the blob
+        /// @tparam DataTy Type of data to get
+        /// @return Pointer to the const data
+        template<typename DataTy>
+        const DataTy *data() const noexcept
+        {
+            return reinterpret_cast<const DataTy *>(xdata.get());
+        }
 
-		/// @brief Get a pointer to the data of the blob
-		/// @tparam DataTy Type of data to get
-		/// @return Pointer to the const data
-		template <typename DataTy>
-		const DataTy* data()const noexcept
-		{
-			return reinterpret_cast<const DataTy*>(xdata.get());
-		}
+        /// @brief Get a pointer to the data of the blob
+        /// @tparam DataTy Type of data to get
+        /// @return Pointer to the data
+        template<typename DataTy>
+        DataTy *data() noexcept
+        {
+            return reinterpret_cast<DataTy *>(xdata.get());
+        }
 
-		/// @brief Get a pointer to the data of the blob
-		/// @tparam DataTy Type of data to get
-		/// @return Pointer to the data
-		template <typename DataTy>
-		DataTy* data()noexcept
-		{
-			return reinterpret_cast<DataTy*>(xdata.get());
-		}
+        /// @brief Get the size of the blob
+        /// @return Size of the blob in bytes
+        [[nodiscard]] size_t size() const noexcept
+        {
+            return xsize;
+        }
 
-		/// @brief Get the size of the blob
-		/// @return Size of the blob in bytes
-		size_t size()const noexcept
-		{
-			return xsize;
-		}
+        /// @brief Get a span of the data
+        /// @tparam DataTy Type of data to get
+        /// @return Immutable span of the data
+        template<typename DataTy>
+        std::span<const DataTy> span() const noexcept
+        {
+            return { data<DataTy>(), xsize };
+        }
 
-		/// @brief Get a span of the data	
-		/// @tparam DataTy Type of data to get
-		/// @return Immutable span of the data
-		template <typename DataTy>
-		std::span<const DataTy> span()const noexcept
-		{
-			return { data<DataTy>(), xsize };
-		}
+        /// @brief Tells if the blob is empty
+        /// @return true if the blob is empty
+        [[nodiscard]] bool empty() const noexcept
+        {
+            return xsize == 0;
+        }
 
-		/// @brief Tells if the blob is empty
-		/// @return true if the blob is empty
-		bool empty()const noexcept
-		{
-			return xsize == 0;
-		}
-	private:
-		std::shared_ptr<std::byte[]> xdata;
-		size_t xsize = 0;
-	};
+    private:
+        std::shared_ptr<std::byte[]> xdata;
+        size_t xsize = 0;
+    };
 }

--- a/wisdom/include/wisdom/api/api_swapchain.h
+++ b/wisdom/include/wisdom/api/api_swapchain.h
@@ -14,111 +14,112 @@ struct wl_surface;
 
 #endif // !WISDOM_MODULES
 
-
 WIS_EXPORT namespace wis
 {
-	/// @brief Describes the format of a texture used to present to the screen.
-	struct SwapchainOptions
-	{
-	public:
-		constexpr static inline auto default_format = DataFormat::b8g8r8a8_unorm; //< Default format for swapchain images.
-		constexpr static inline auto default_frames = 2u; //< Default number of swapchain images.
-	public:
-		SwapchainOptions() = default;
+    /// @brief Describes the format of a texture used to present to the screen.
+    struct SwapchainOptions {
+        constexpr static inline auto default_format = DataFormat::b8g8r8a8_unorm; //< Default format for swapchain images.
+        constexpr static inline auto default_frames = 2u; //< Default number of swapchain images.
+        constexpr static inline uint32_t default_width = 1280;
+        constexpr static inline uint32_t default_height = 720;
 
-		/// @brief Construct a swapchain options.
-		/// @param width Width of the swapchain images.
-		/// @param height Height of the swapchain images.
-		/// @param frame_count Number of swapchain images.
-		/// @param format Data format of the swapchain images.
-		/// @param stereo Stereo support.
-		SwapchainOptions(uint32_t width, uint32_t height, uint32_t frame_count = default_frames, DataFormat format = default_format, bool stereo = false)
-			:width(width), height(height), frame_count(frame_count), format(format), stereo(stereo)
-		{}
-	public:
-		uint32_t width = 1280; //< Width of the swapchain images.
-		uint32_t height = 720; //< Height of the swapchain images.
-		uint32_t frame_count = default_frames; //< Number of swapchain images.
-		DataFormat format = default_format; //< Format of the swapchain images.
-		bool stereo = false; //< Ask the swapchain images for stereo support.
-	};
+        SwapchainOptions() = default;
 
+        /// @brief Construct a swapchain options.
+        /// @param width Width of the swapchain images.
+        /// @param height Height of the swapchain images.
+        /// @param frame_count Number of swapchain images.
+        /// @param format Data format of the swapchain images.
+        /// @param stereo Stereo support.
+        SwapchainOptions(uint32_t width, uint32_t height, uint32_t frame_count = default_frames, DataFormat format = default_format, bool stereo = false)
+            : width(width), height(height), frame_count(frame_count), format(format), stereo(stereo)
+        {
+        }
 
-	// TODO: Wayland and WinUI composition.
-	/// @brief Describes the output surface parameters.
-	struct SurfaceParameters
-	{
-		/// @brief Type of the surface. Depends on the platform.
-		enum class Type {
-			None,
-			Win32,
-			WinRT,
-			X11,
-			Metal,
+        uint32_t width = default_width; //< Width of the swapchain images.
+        uint32_t height = default_height; //< Height of the swapchain images.
+        uint32_t frame_count = default_frames; //< Number of swapchain images.
+        DataFormat format = default_format; //< Format of the swapchain images.
+        bool stereo = false; //< Ask the swapchain images for stereo support.
+    };
+
+    // TODO: Wayland and WinUI composition.
+    /// @brief Describes the output surface parameters.
+    struct SurfaceParameters {
+        /// @brief Type of the surface. Depends on the platform.
+        enum class Type {
+            None,
+            Win32,
+            WinRT,
+            X11,
+            Metal,
             Wayland
-		};
-	public:
-		SurfaceParameters() = default;
+        };
+
+        SurfaceParameters() = default;
 #if WISDOM_WINDOWS
-		/// @brief Create a surface parameters for a Win32 window.
-		/// @param hwnd Win32 window handle.
-		explicit SurfaceParameters(HWND hwnd)
-			:type(Type::Win32), hwnd(hwnd)
-		{}
+        /// @brief Create a surface parameters for a Win32 window.
+        /// @param hwnd Win32 window handle.
+        explicit SurfaceParameters(HWND hwnd)
+            : type(Type::Win32), hwnd(hwnd)
+        {
+        }
 #endif
 #if WISDOM_UWP
-		/// @brief Create a surface parameters for a WinRT CoreWindow.
-		/// @param core_window Pointer to the CoreWindow.
-		explicit SurfaceParameters(IUnknown* core_window)
-			:type(Type::WinRT), core_window(core_window)
-		{}
+        /// @brief Create a surface parameters for a WinRT CoreWindow.
+        /// @param core_window Pointer to the CoreWindow.
+        explicit SurfaceParameters(IUnknown *core_window)
+            : type(Type::WinRT), core_window(core_window)
+        {
+        }
 #endif
 #if WISDOM_LINUX
-		/// @brief Create a surface parameters for a X11 window.
-		/// @param connection X11 connection.
-		/// @param window X11 window.
-		explicit SurfaceParameters(xcb_connection_t* connection, xcb_window_t window)
-			:type(Type::X11), x11{ connection, window }
-		{}
-        
+        /// @brief Create a surface parameters for a X11 window.
+        /// @param connection X11 connection.
+        /// @param window X11 window.
+        explicit SurfaceParameters(xcb_connection_t *connection, xcb_window_t window)
+            : type(Type::X11), x11{ connection, window }
+        {
+        }
+
         /// @brief Create a surface parameters struct for a wayland window.
         /// @param display wayland display handle
         /// @param surface wayland surface handle
-        explicit SurfaceParameters(wl_display* display,  wl_surface* surface)
-			:type(Type::Wayland), wayland{ display, surface }
-		{}
+        explicit SurfaceParameters(wl_display *display, wl_surface *surface)
+            : type(Type::Wayland), wayland{ display, surface }
+        {
+        }
 #endif
 #if WISDOM_MACOS
-		/// @brief Create a surface parameters for a Metal layer.
-		/// @param layer Metal layer.
-		explicit SurfaceParameters(CAMetalLayer* layer)
-			:type(Type::Metal), layer(layer)
-		{}
+        /// @brief Create a surface parameters for a Metal layer.
+        /// @param layer Metal layer.
+        explicit SurfaceParameters(CAMetalLayer *layer)
+            : type(Type::Metal), layer(layer)
+        {
+        }
 #endif
-	public:
-		Type type = Type::None; //< Type of the surface.
-		union
-		{
+        Type type = Type::None; //< Type of the surface.
+        union {
 #if WISDOM_WINDOWS
-			HWND hwnd; //< Win32 window handle.
+            HWND hwnd; //< Win32 window handle.
 #endif // WISDOM_WINDOWS
 #if WISDOM_UWP
-			IUnknown* core_window; //< WinRT CoreWindow.
+            IUnknown *core_window; //< WinRT CoreWindow.
 #endif // WISDOM_UWP
 #if WISDOM_LINUX
-			struct
-			{
-				xcb_connection_t* connection; //< X11 connection.
-				xcb_window_t window; //< X11 window handle.
-		}x11; //< X11 window.
+            struct
+            {
+                xcb_connection_t *connection; //< X11 connection.
+                xcb_window_t window; //< X11 window handle.
+            } x11; //< X11 window.
             struct {
-                wl_display* display;
-                wl_surface* surface;
+                wl_display *display;
+                wl_surface *surface;
             } wayland;
 #endif // WISDOM_LINUX
 #if WISDOM_MACOS
-			CAMetalLayer* layer; //< Metal layer.
+            CAMetalLayer *layer; //< Metal layer.
 #endif // WISDOM_MACOS
-	};
-};
+        };
+    };
 }

--- a/wisdom/include/wisdom/bridge/format.h
+++ b/wisdom/include/wisdom/bridge/format.h
@@ -3,17 +3,16 @@
 #include <fmt/xchar.h>
 WIS_EXPORT namespace wis
 {
-	using fmt::format;
-	using fmt::format_to;
+    using fmt::format; // NOLINT
+    using fmt::format_to; // NOLINT
 }
 #elif __has_include(<format>)
 #include <format>
 WIS_EXPORT namespace wis
 {
-	using std::format;
-	using std::format_to;
+    using std::format;
+    using std::format_to;
 }
 #else
 #error "wisdom requires fmt or std::format"
 #endif
-

--- a/wisdom/include/wisdom/bridge/source_location.h
+++ b/wisdom/include/wisdom/bridge/source_location.h
@@ -1,15 +1,13 @@
 #pragma once
 #if __has_include(<source_location>)
 #include <source_location>
-namespace wis
-{
-	using std::source_location;
+namespace wis {
+using std::source_location;
 }
 #elif __has_include(<experimental/source_location>)
 #include <experimental/source_location>
-namespace wis
-{
-	using std::experimental::source_location;
+namespace wis {
+using std::experimental::source_location;
 }
 #else
 #error "No source_location header found"

--- a/wisdom/include/wisdom/dx12/dx12_adapter.h
+++ b/wisdom/include/wisdom/dx12/dx12_adapter.h
@@ -9,45 +9,46 @@
 #include <dxgi.h>
 #endif // !WISDOM_MODULES
 
-
 WIS_EXPORT namespace wis
 {
-	class DX12Adapter;
+    class DX12Adapter;
 
-	template<>
-	class Internal<DX12Adapter>
-	{
-	public:
-		Internal() = default;
-		Internal(winrt::com_ptr<IDXGIAdapter1> adapter)noexcept
-			:adapter(std::move(adapter)) {}
-	public:
-		[[nodiscard]]IDXGIAdapter1* GetAdapter()const noexcept {
-			return adapter.get();
-		}
-	protected:
-		winrt::com_ptr<IDXGIAdapter1> adapter;
-	};
+    template<>
+    class Internal<DX12Adapter>
+    {
+    public:
+        Internal() = default;
+        Internal(winrt::com_ptr<IDXGIAdapter1> adapter) noexcept
+            : adapter(std::move(adapter)) { }
 
+        [[nodiscard]] IDXGIAdapter1 *GetAdapter() const noexcept
+        {
+            return adapter.get();
+        }
 
-	/// @brief DX12 physical adapter
-	class DX12Adapter final : public QueryInternal<DX12Adapter>
-	{
-	public:
-		DX12Adapter() = default;
-		explicit DX12Adapter(winrt::com_ptr<IDXGIAdapter1> adapter)noexcept
-			:QueryInternal(std::move(adapter))
-		{}
-		operator DX12AdapterView()const noexcept{
-			return GetAdapter();
-		}
-	public:
+    protected:
+        winrt::com_ptr<IDXGIAdapter1> adapter;
+    };
 
-		/// @brief Get the adapter description
-		/// @return Adapter Description
-		/// @note This function is thread safe
-		WIS_INLINE [[nodiscard]]AdapterDesc GetDesc()const noexcept;
-	};
+    /// @brief DX12 physical adapter
+    class DX12Adapter final : public QueryInternal<DX12Adapter>
+    {
+    public:
+        DX12Adapter() = default;
+        explicit DX12Adapter(winrt::com_ptr<IDXGIAdapter1> adapter) noexcept
+            : QueryInternal(std::move(adapter))
+        {
+        }
+        operator DX12AdapterView() const noexcept
+        {
+            return GetAdapter();
+        }
+
+        /// @brief Get the adapter description
+        /// @return Adapter Description
+        /// @note This function is thread safe
+        WIS_INLINE [[nodiscard]] AdapterDesc GetDesc() const noexcept;
+    };
 }
 
 #if defined(WISDOM_HEADER_ONLY)

--- a/wisdom/include/wisdom/dx12/dx12_allocator.h
+++ b/wisdom/include/wisdom/dx12/dx12_allocator.h
@@ -30,7 +30,6 @@ WIS_EXPORT namespace wis
         DX12ResourceAllocator() = default;
         WIS_INLINE explicit DX12ResourceAllocator(DX12DeviceView device, DX12AdapterView adapter);
 
-    public:
         /// @brief Create a buffer that is persistently mapped to the GPU
         /// @param size Size of the buffer
         /// @param flags Type of buffer

--- a/wisdom/include/wisdom/dx12/dx12_buffer_views.h
+++ b/wisdom/include/wisdom/dx12/dx12_buffer_views.h
@@ -6,34 +6,38 @@
 
 WIS_EXPORT namespace wis
 {
-	class DX12VertexBufferView;
+    class DX12VertexBufferView;
 
-	template<>
-	class Internal<DX12VertexBufferView>
-	{
-	public:
-		Internal() = default;
-		Internal(D3D12_VERTEX_BUFFER_VIEW view) :view(view) {}
-	public:
-		[[nodiscard]] D3D12_VERTEX_BUFFER_VIEW GetView()const noexcept{
-			return view;
-		}
-	protected:
-		D3D12_VERTEX_BUFFER_VIEW view;
-	};
+    template<>
+    class Internal<DX12VertexBufferView>
+    {
+    public:
+        Internal() = default;
+        Internal(D3D12_VERTEX_BUFFER_VIEW view)
+            : view(view) { }
 
-	/// @brief Vertex buffer view
-	class DX12VertexBufferView : public QueryInternal<DX12VertexBufferView>
-	{
-	public:
-		DX12VertexBufferView() = default;
-		explicit DX12VertexBufferView(D3D12_VERTEX_BUFFER_VIEW xhandle)
-			:base(xhandle) {}
-	public:
-		/// @brief Get the view
-		/// @note This function is only available in the internal API
-		operator D3D12_VERTEX_BUFFER_VIEW()const noexcept{
-			return view;
-		}
-	};
+        [[nodiscard]] D3D12_VERTEX_BUFFER_VIEW GetView() const noexcept
+        {
+            return view;
+        }
+
+    protected:
+        D3D12_VERTEX_BUFFER_VIEW view;
+    };
+
+    /// @brief Vertex buffer view
+    class DX12VertexBufferView : public QueryInternal<DX12VertexBufferView>
+    {
+    public:
+        DX12VertexBufferView() = default;
+        explicit DX12VertexBufferView(D3D12_VERTEX_BUFFER_VIEW xhandle)
+            : base(xhandle) { }
+
+        /// @brief Get the view
+        /// @note This function is only available in the internal API
+        operator D3D12_VERTEX_BUFFER_VIEW() const noexcept
+        {
+            return view;
+        }
+    };
 }

--- a/wisdom/include/wisdom/dx12/dx12_checks.h
+++ b/wisdom/include/wisdom/dx12/dx12_checks.h
@@ -7,97 +7,101 @@
 
 WIS_EXPORT namespace wis
 {
-	class hr_exception :public wis::exception
-	{
-	public:
-		WIS_INLINE hr_exception(winrt::hresult hr, wis::source_location sl = wis::source_location::current());
-	public:
-		WIS_INLINE const char* what() const noexcept override;
-		std::string_view type()const noexcept override
-		{
-			return "Vertas Window Exception";
-		}
-		winrt::hresult error_code() const noexcept
-		{
-			return hResult;
-		}
-		WIS_INLINE std::string description() const noexcept;
-	private:
-		winrt::hresult hResult;
-	};
+    class hr_exception : public wis::exception
+    {
+    public:
+        WIS_INLINE hr_exception(winrt::hresult hr, wis::source_location sl = wis::source_location::current());
 
+        WIS_INLINE const char *what() const noexcept override;
+        std::string_view type() const noexcept override
+        {
+            return "Vertas Window Exception";
+        }
+        winrt::hresult error_code() const noexcept
+        {
+            return hResult;
+        }
+        WIS_INLINE std::string description() const noexcept;
 
+    private:
+        winrt::hresult hResult;
+    };
 
-	/// @brief Log any errors in the current context
-	/// @return true if there were any errors
-	WIS_INLINE bool log_dxgi_errors()noexcept;
+    /// @brief Log any errors in the current context
+    /// @return true if there were any errors
+    WIS_INLINE bool log_dxgi_errors() noexcept;
 
-	/// @brief Get the last windows error
-	/// @return HRESULT of the last windows error
-	WIS_INLINE winrt::hresult last_windows_error() noexcept;
+    /// @brief Get the last windows error
+    /// @return HRESULT of the last windows error
+    WIS_INLINE winrt::hresult last_windows_error() noexcept;
 
-	/// @brief Chaeck if there are any errors in the current context, logging any errors
-	/// @param sl Source location
-	inline void check_context(wis::source_location sl = wis::source_location::current())
-	{
-		if constexpr (debug_mode)
-			if (log_dxgi_errors())
-				throw wis::exception{ sl };
-	}
+    /// @brief Chaeck if there are any errors in the current context, logging any errors
+    /// @param sl Source location
+    inline void check_context(wis::source_location sl = wis::source_location::current())
+    {
+        if constexpr (debug_mode)
+            if (log_dxgi_errors())
+                throw wis::exception{ sl };
+    }
 
-	/// @brief Check if the given boolean is true, logging any errors
-	/// @param check Value to check
-	/// @param sl Source location
-	inline void check_bool(bool check, wis::source_location sl = wis::source_location::current())
-	{
-		if (check)return;
-		log_dxgi_errors();
-		throw wis::exception{ sl };
-	}
+    /// @brief Check if the given boolean is true, logging any errors
+    /// @param check Value to check
+    /// @param sl Source location
+    inline void check_bool(bool check, wis::source_location sl = wis::source_location::current())
+    {
+        if (check)
+            return;
+        log_dxgi_errors();
+        throw wis::exception{ sl };
+    }
 
-	/// @brief Check if the given HRESULT is a success code, logging any errors and throwing an exception if it is not a success code
-	/// @param hr HRESULT to check
-	/// @param sl Source location
-	inline void check_hresult(winrt::hresult hr, wis::source_location sl = wis::source_location::current())
-	{
-		log_dxgi_errors();
-		if (hr >= 0)return;
-		throw wis::hr_exception{ hr, sl };
-	}
+    /// @brief Check if the given HRESULT is a success code, logging any errors and throwing an exception if it is not a success code
+    /// @param hr HRESULT to check
+    /// @param sl Source location
+    inline void check_hresult(winrt::hresult hr, wis::source_location sl = wis::source_location::current())
+    {
+        log_dxgi_errors();
+        if (hr >= 0)
+            return;
+        throw wis::hr_exception{ hr, sl };
+    }
 
-	/// @brief Check if the given HRESULT is a success code, logging any errors
-	/// @param hr HRESULT to check
-	/// @return true if the HRESULT is a success code
-	inline [[nodiscard]] bool check_hresult_nothrow(winrt::hresult hr)noexcept
-	{
-		log_dxgi_errors();
-		return hr >= 0;
-	}
+    /// @brief Check if the given HRESULT is a success code, logging any errors
+    /// @param hr HRESULT to check
+    /// @return true if the HRESULT is a success code
+    inline [[nodiscard]] bool check_hresult_nothrow(winrt::hresult hr) noexcept
+    {
+        log_dxgi_errors();
+        return hr >= 0;
+    }
 
-	/// @brief Check if the given boolean is true, logging any errors and throwing a windows exception if it is not true
-	/// @param check Value to check
-	/// @param sl Source location
-	inline void check_windows(bool check, wis::source_location sl = wis::source_location::current())
-	{
-		if (check)return;
-		throw wis::hr_exception{ last_windows_error(), sl };
-	}
+    /// @brief Check if the given boolean is true, logging any errors and throwing a windows exception if it is not true
+    /// @param check Value to check
+    /// @param sl Source location
+    inline void check_windows(bool check, wis::source_location sl = wis::source_location::current())
+    {
+        if (check)
+            return;
+        throw wis::hr_exception{ last_windows_error(), sl };
+    }
 
-	/// @brief Check if the given HRESULT is a success code, logging any errors and throwing a windows exception if it is not a success code
-	/// @param hr HRESULT to check
-	/// @return True if the HRESULT is a success code
-	inline bool succeded(winrt::hresult hr)noexcept { return check_hresult_nothrow(hr); }
+    /// @brief Check if the given HRESULT is a success code, logging any errors and throwing a windows exception if it is not a success code
+    /// @param hr HRESULT to check
+    /// @return True if the HRESULT is a success code
+    inline bool succeded(winrt::hresult hr) noexcept
+    {
+        return check_hresult_nothrow(hr);
+    }
 
-	
-	/// @brief Check if the given HRESULT a success code, without logging, serves as an assert
-	/// @param hr HRESULT to check
-	/// @return True if the HRESULT is a success code
-	inline bool succeded_weak(winrt::hresult hr)
-	{
-		if constexpr (!debug_mode || !runtime_asserts)
-			return hr >= 0;
-		return check_hresult_nothrow(hr);
-	}
+    /// @brief Check if the given HRESULT a success code, without logging, serves as an assert
+    /// @param hr HRESULT to check
+    /// @return True if the HRESULT is a success code
+    inline bool succeded_weak(winrt::hresult hr)
+    {
+        if constexpr (!debug_mode || !runtime_asserts)
+            return hr >= 0;
+        return check_hresult_nothrow(hr);
+    }
 }
 
 #if defined(WISDOM_HEADER_ONLY)

--- a/wisdom/include/wisdom/dx12/dx12_command_queue.h
+++ b/wisdom/include/wisdom/dx12/dx12_command_queue.h
@@ -8,50 +8,53 @@
 
 WIS_EXPORT namespace wis
 {
-	class DX12CommandQueue;
+    class DX12CommandQueue;
 
-	template<>
-	class Internal<DX12CommandQueue>
-	{
-	public:
-		Internal() = default;
-		Internal(winrt::com_ptr<ID3D12CommandQueue> queue)noexcept :queue(std::move(queue)){}
-	public:
-		[[nodiscard]] ID3D12CommandQueue* GetQueue()const noexcept {
-			return queue.get();
-		}
-	protected:
-		winrt::com_ptr<ID3D12CommandQueue> queue{};
-	};
+    template<>
+    class Internal<DX12CommandQueue>
+    {
+    public:
+        Internal() = default;
+        Internal(winrt::com_ptr<ID3D12CommandQueue> queue) noexcept
+            : queue(std::move(queue)) { }
 
+        [[nodiscard]] ID3D12CommandQueue *GetQueue() const noexcept
+        {
+            return queue.get();
+        }
 
-	/// @brief A command queue is used to submit command lists to the GPU.
-	class DX12CommandQueue : public QueryInternal<DX12CommandQueue>
-	{
-		using intern = QueryInternal<DX12CommandQueue>;
-	public:
-		DX12CommandQueue() = default;
-		explicit DX12CommandQueue(winrt::com_ptr<ID3D12CommandQueue> queue)noexcept
-			:intern(std::move(queue)){}
-		operator DX12CommandQueueView()const noexcept{
-			return GetQueue();
-		}
-	public:
+    protected:
+        winrt::com_ptr<ID3D12CommandQueue> queue{};
+    };
 
-		/// @brief Execute a command list on the GPU.
-		/// @param list List to execute.
-		void ExecuteCommandList(DX12CommandListView list)noexcept
-		{
-			queue->ExecuteCommandLists(1, reinterpret_cast<ID3D12CommandList* const*>(&list));
-		}
+    /// @brief A command queue is used to submit command lists to the GPU.
+    class DX12CommandQueue : public QueryInternal<DX12CommandQueue>
+    {
+        using intern = QueryInternal<DX12CommandQueue>;
 
-		/// @brief Signal a fence with some value.
-		/// @param fence Fence to signal.
-		/// @param value Value to signal with.
-		/// @return true if call succeeded.
-		bool Signal(DX12FenceView fence, uint64_t value)noexcept
-		{
-			return wis::succeded_weak(queue->Signal(fence, value));
-		}
-	};
+    public:
+        DX12CommandQueue() = default;
+        explicit DX12CommandQueue(winrt::com_ptr<ID3D12CommandQueue> queue) noexcept
+            : intern(std::move(queue)) { }
+        operator DX12CommandQueueView() const noexcept
+        {
+            return GetQueue();
+        }
+
+        /// @brief Execute a command list on the GPU.
+        /// @param list List to execute.
+        void ExecuteCommandList(DX12CommandListView list) noexcept
+        {
+            queue->ExecuteCommandLists(1, reinterpret_cast<ID3D12CommandList *const *>(&list));
+        }
+
+        /// @brief Signal a fence with some value.
+        /// @param fence Fence to signal.
+        /// @param value Value to signal with.
+        /// @return true if call succeeded.
+        bool Signal(DX12FenceView fence, uint64_t value) noexcept
+        {
+            return wis::succeded_weak(queue->Signal(fence, value));
+        }
+    };
 }

--- a/wisdom/include/wisdom/dx12/dx12_definitions.h
+++ b/wisdom/include/wisdom/dx12/dx12_definitions.h
@@ -6,15 +6,14 @@
 #include <dxgi1_6.h>
 #include <array>
 
-namespace wis
+namespace wis {
+/// @brief Get the array view of com_ptr
+/// @tparam C Type of the com_ptr, deduced from the argument
+/// @param self Pointer
+/// @return Array view of the pointer
+template<class C>
+[[nodiscard]] inline auto **array_view(winrt::com_ptr<C> &self)
 {
-	/// @brief Get the array view of com_ptr
-	/// @tparam C Type of the com_ptr, deduced from the argument
-	/// @param self Pointer
-	/// @return Array view of the pointer
-	template<class C>
-	[[nodiscard]] inline auto** array_view(winrt::com_ptr<C>& self)
-	{
-		return reinterpret_cast<C**>(&self);
-	}
+    return reinterpret_cast<C **>(&self);
 }
+} // namespace wis

--- a/wisdom/include/wisdom/dx12/dx12_descriptor_heap.h
+++ b/wisdom/include/wisdom/dx12/dx12_descriptor_heap.h
@@ -46,7 +46,6 @@ WIS_EXPORT namespace wis
 
     class DX12DescriptorSet;
 
-
     template<>
     class Internal<DX12DescriptorSet>
     {

--- a/wisdom/include/wisdom/dx12/dx12_device.h
+++ b/wisdom/include/wisdom/dx12/dx12_device.h
@@ -89,7 +89,7 @@ WIS_EXPORT namespace wis
 
         /// @brief Create a graphics pipeline
         [[nodiscard]] WIS_INLINE DX12PipelineState CreateGraphicsPipeline(
-                DX12GraphicsPipelineDesc desc,
+                const DX12GraphicsPipelineDesc &desc,
                 std::span<const InputLayoutDesc> input_layout) const;
 
         /// @brief Create a shader

--- a/wisdom/include/wisdom/dx12/dx12_factory.h
+++ b/wisdom/include/wisdom/dx12/dx12_factory.h
@@ -8,93 +8,98 @@
 #include <dxgi1_6.h>
 #endif
 
-
 WIS_EXPORT namespace wis
 {
-	class DX12Factory;
+    class DX12Factory;
 
-	template<>
-	class Internal<DX12Factory>
-	{
-	public:
-		Internal()
-		{
-			if (factory)
-				factory->AddRef();
-		}
-		~Internal()
-		{
-			if (!factory->Release())
-				factory.detach();
-		}
-	public:
-		[[nodiscard]]
-		static IDXGIFactory4* GetFactory()noexcept {
-			return factory.get();
-		}
-	protected:
-		static inline winrt::com_ptr<IDXGIFactory4> factory{};
-	};
+    template<>
+    class Internal<DX12Factory>
+    {
+    public:
+        Internal()
+        {
+            if (factory)
+                factory->AddRef();
+        }
+        ~Internal()
+        {
+            if (!factory->Release())
+                factory.detach();
+        }
 
+    public:
+        [[nodiscard]] static IDXGIFactory4 *GetFactory() noexcept
+        {
+            return factory.get();
+        }
 
-	/// @brief Main Factory class, since we don't need more than one factory it is a static resource
-	/// @note Not thread safe on creation
-	class DX12Factory final : public QueryInternal<DX12Factory>
-	{
-		friend class DX12Device;
-		friend class DX12Surface;
-		static inline constexpr uint32_t debug_flag = wis::debug_mode & DXGI_CREATE_FACTORY_DEBUG;
-	public:
-		/// @brief Creates a new factory
-		/// @param app_info Application info, not used
-		///	@param use_preference Use the preference when enumerating adapters
-		WIS_INLINE DX12Factory([[maybe_unused]] const ApplicationInfo& app_info, bool use_preference = true);
-	public:
-		/// @brief Enumerates all adapters on the system
-		/// @param preference Preference to use when enumerating adapters, changes the order of the adapters
-		/// @return coroutine that yields DX12Adapter
-		WIS_INLINE [[nodiscard]] wis::generator<DX12Adapter> EnumerateAdapters(AdapterPreference preference = AdapterPreference::Performance)const noexcept;
-	public:
-		/// @brief Used as a direct bridge to the IDXGIFactory, used only by internal classes
-		/// @return Factory interface
-		[[nodiscard]] static auto GetFactory()noexcept {
-			return factory;
-		}
-	private:
+    protected:
+        static inline winrt::com_ptr<IDXGIFactory4> factory{};
+    };
 
-		/// @brief enables the debug layer if debug mode is enabled by compiler
-		WIS_INLINE void EnableDebugLayer() noexcept;
+    /// @brief Main Factory class, since we don't need more than one factory it is a static resource
+    /// @note Not thread safe on creation
+    class DX12Factory final : public QueryInternal<DX12Factory>
+    {
+        friend class DX12Device;
+        friend class DX12Surface;
+        static inline constexpr uint32_t debug_flag = wis::debug_mode & DXGI_CREATE_FACTORY_DEBUG;
 
-		/// @brief Enumerates all adapters on the system by GPU preference
-		/// @param preference Specifies the GPU preference
-		/// @return Coroutine that yields IDXGIAdapter1
-		WIS_INLINE wis::generator<winrt::com_ptr<IDXGIAdapter1>>
-			AdaptersByGPUPreference(DXGI_GPU_PREFERENCE preference = DXGI_GPU_PREFERENCE::DXGI_GPU_PREFERENCE_HIGH_PERFORMANCE)const noexcept;
+    public:
+        /// @brief Creates a new factory
+        /// @param app_info Application info, not used
+        ///	@param use_preference Use the preference when enumerating adapters
+        WIS_INLINE DX12Factory([[maybe_unused]] const ApplicationInfo &app_info, bool use_preference = true);
 
-		/// @brief Enumerates all adapters on the system
-		/// @return Coroutine that yields IDXGIAdapter1
-		WIS_INLINE wis::generator<winrt::com_ptr<IDXGIAdapter1>>
-			Adapters()const noexcept;
+    public:
+        /// @brief Enumerates all adapters on the system
+        /// @param preference Preference to use when enumerating adapters, changes the order of the adapters
+        /// @return coroutine that yields DX12Adapter
+        WIS_INLINE [[nodiscard]] wis::generator<DX12Adapter> EnumerateAdapters(AdapterPreference preference = AdapterPreference::Performance) const noexcept;
 
-		/// @brief Creates a swapchain for a core window
-		/// @param desc Description of the swapchain
-		/// @param core_window Core window to create the swapchain for
-		/// @param queue Queue to use for the swapchain
-		/// @return Handle to the swapchain
-		WIS_INLINE [[nodiscard]] static winrt::com_ptr<IDXGISwapChain4>
-			SwapChainForCoreWindow(const DXGI_SWAP_CHAIN_DESC1& desc, IUnknown* core_window, IUnknown* queue);
+    public:
+        /// @brief Used as a direct bridge to the IDXGIFactory, used only by internal classes
+        /// @return Factory interface
+        [[nodiscard]] static auto GetFactory() noexcept
+        {
+            return factory;
+        }
 
-		/// @brief Creates a swapchain for a win32 window
-		/// @param desc Description of the swapchain
-		/// @param hwnd Window handle to create the swapchain for
-		/// @param queue Queue to use for the swapchain
-		/// @return Handle to the swapchain
-		WIS_INLINE [[nodiscard]] static winrt::com_ptr<IDXGISwapChain4>
-			SwapChainForWin32(const DXGI_SWAP_CHAIN_DESC1& desc, HWND hwnd, IUnknown* queue);
-	private:
-		static inline bool has_preference = false; //< if the user has specified a preference for adapters
-		DX12Info info; //< infromation queue for debugging and error messages
-	};
+    private:
+        /// @brief enables the debug layer if debug mode is enabled by compiler
+        WIS_INLINE void EnableDebugLayer() noexcept;
+
+        /// @brief Enumerates all adapters on the system by GPU preference
+        /// @param preference Specifies the GPU preference
+        /// @return Coroutine that yields IDXGIAdapter1
+        WIS_INLINE wis::generator<winrt::com_ptr<IDXGIAdapter1>>
+        AdaptersByGPUPreference(DXGI_GPU_PREFERENCE preference = DXGI_GPU_PREFERENCE::DXGI_GPU_PREFERENCE_HIGH_PERFORMANCE) const noexcept;
+
+        /// @brief Enumerates all adapters on the system
+        /// @return Coroutine that yields IDXGIAdapter1
+        WIS_INLINE wis::generator<winrt::com_ptr<IDXGIAdapter1>>
+        Adapters() const noexcept;
+
+        /// @brief Creates a swapchain for a core window
+        /// @param desc Description of the swapchain
+        /// @param core_window Core window to create the swapchain for
+        /// @param queue Queue to use for the swapchain
+        /// @return Handle to the swapchain
+        WIS_INLINE [[nodiscard]] static winrt::com_ptr<IDXGISwapChain4>
+        SwapChainForCoreWindow(const DXGI_SWAP_CHAIN_DESC1 &desc, IUnknown *core_window, IUnknown *queue);
+
+        /// @brief Creates a swapchain for a win32 window
+        /// @param desc Description of the swapchain
+        /// @param hwnd Window handle to create the swapchain for
+        /// @param queue Queue to use for the swapchain
+        /// @return Handle to the swapchain
+        WIS_INLINE [[nodiscard]] static winrt::com_ptr<IDXGISwapChain4>
+        SwapChainForWin32(const DXGI_SWAP_CHAIN_DESC1 &desc, HWND hwnd, IUnknown *queue);
+
+    private:
+        static inline bool has_preference = false; //< if the user has specified a preference for adapters
+        DX12Info info; //< infromation queue for debugging and error messages
+    };
 }
 
 #if defined(WISDOM_HEADER_ONLY)

--- a/wisdom/include/wisdom/dx12/dx12_fence.h
+++ b/wisdom/include/wisdom/dx12/dx12_fence.h
@@ -8,88 +8,91 @@
 
 WIS_EXPORT namespace wis
 {
-	class DX12Fence;
+    class DX12Fence;
 
-	template<>
-	class Internal<DX12Fence>
-	{
-		struct unique_event
-		{
-			unique_event() :event(CreateEvent(nullptr, false, false, nullptr)){}
-			unique_event(unique_event const&) = delete;
-			unique_event& operator=(unique_event const&) = delete;
-			unique_event(unique_event&&) = default;
-			unique_event& operator=(unique_event&&) = default;
-			~unique_event()
-			{
-				event.close();
-			}
-			operator HANDLE()const noexcept
-			{
-				return event.get();
-			}
-			operator bool()const noexcept
-			{
-				return bool(event);
-			}
-			bool wait()const noexcept
-			{
-				return WaitForSingleObject(event.get(), INFINITE) == WAIT_OBJECT_0;
-			}
-		public:
-			winrt::handle event;
-		};
-	public:
-		Internal() = default;
-		Internal(winrt::com_ptr<ID3D12Fence1> fence) 
-			: fence(std::move(fence))
-		{
-			wis::check_bool(fence_event);
-		}
-	public:
-		[[nodiscard]]
-		auto* GetFence()const noexcept {
-			return fence.get();
-		}
-	protected:
-		winrt::com_ptr<ID3D12Fence1> fence;
-		unique_event fence_event;
-	};
+    template<>
+    class Internal<DX12Fence>
+    {
+        struct unique_event {
+            unique_event()
+                : event(CreateEvent(nullptr, false, false, nullptr)) { }
+            unique_event(unique_event const &) = delete;
+            unique_event &operator=(unique_event const &) = delete;
+            unique_event(unique_event &&) = default;
+            unique_event &operator=(unique_event &&) = default;
+            ~unique_event()
+            {
+                event.close();
+            }
+            operator HANDLE() const noexcept
+            {
+                return event.get();
+            }
+            operator bool() const noexcept
+            {
+                return bool(event);
+            }
+            bool wait() const noexcept
+            {
+                return WaitForSingleObject(event.get(), INFINITE) == WAIT_OBJECT_0;
+            }
 
+        public:
+            winrt::handle event;
+        };
 
-	/// @brief A fence is a synchronization primitive that allows the CPU to wait for the GPU to finish rendering a frame.
-	class DX12Fence : public QueryInternal<DX12Fence>
-	{
-	public:
-		DX12Fence() = default;
-		explicit DX12Fence(winrt::com_ptr<ID3D12Fence1> xfence)noexcept
-			: QueryInternal(std::move(xfence)){}
-		operator DX12FenceView()const noexcept{
-			return GetFence();
-		}
-	public:
-		/// @brief Get the current value of the fence.
-		/// @return Value of the fence.
-		uint64_t GetCompletedValue()const noexcept
-		{
-			return fence->GetCompletedValue();
-		}
+    public:
+        Internal() = default;
+        Internal(winrt::com_ptr<ID3D12Fence1> fence)
+            : fence(std::move(fence))
+        {
+            wis::check_bool(fence_event);
+        }
 
-		/// @brief Wait for the fence to reach a certain value.
-		/// @param value Value to wait for.
-		/// @return Boolean indicating whether the fence reached the value.
-		bool Wait(uint64_t value)const noexcept
-		{
-			return GetCompletedValue() >= value ?
-				true : wis::succeded_weak(fence->SetEventOnCompletion(value, fence_event))
-				&& fence_event.wait();
-		}
+    public:
+        [[nodiscard]] auto *GetFence() const noexcept
+        {
+            return fence.get();
+        }
 
-		/// @brief Signal the fence from CPU.
-		/// @param value Value to signal.
-		void Signal(uint64_t value)noexcept
-		{
-			fence->Signal(value);
-		}
-	};
+    protected:
+        winrt::com_ptr<ID3D12Fence1> fence;
+        unique_event fence_event;
+    };
+
+    /// @brief A fence is a synchronization primitive that allows the CPU to wait for the GPU to finish rendering a frame.
+    class DX12Fence : public QueryInternal<DX12Fence>
+    {
+    public:
+        DX12Fence() = default;
+        explicit DX12Fence(winrt::com_ptr<ID3D12Fence1> xfence) noexcept
+            : QueryInternal(std::move(xfence)) { }
+        operator DX12FenceView() const noexcept
+        {
+            return GetFence();
+        }
+
+    public:
+        /// @brief Get the current value of the fence.
+        /// @return Value of the fence.
+        uint64_t GetCompletedValue() const noexcept
+        {
+            return fence->GetCompletedValue();
+        }
+
+        /// @brief Wait for the fence to reach a certain value.
+        /// @param value Value to wait for.
+        /// @return Boolean indicating whether the fence reached the value.
+        bool Wait(uint64_t value) const noexcept
+        {
+            return GetCompletedValue() >= value ? true : wis::succeded_weak(fence->SetEventOnCompletion(value, fence_event)) && fence_event.wait();
+        }
+
+        /// @brief Signal the fence from CPU.
+        /// @param value Value to signal.
+        void Signal(uint64_t value) noexcept
+        {
+            fence->Signal(value);
+        }
+    };
 }

--- a/wisdom/include/wisdom/dx12/dx12_info.h
+++ b/wisdom/include/wisdom/dx12/dx12_info.h
@@ -6,30 +6,30 @@
 #include <dxgidebug.h>
 #endif // !WISDOM_MODULES
 
-
 WIS_EXPORT namespace wis
 {
-	/// @brief Message struct for debug and error messagesW
-	struct DXGIMessage
-	{
-		Severity severity; //< Severity of the message
-		std::string description; //< Description of the message
-	};
+    /// @brief Message struct for debug and error messagesW
+    struct DXGIMessage {
+        Severity severity; //< Severity of the message
+        std::string description; //< Description of the message
+    };
 
-	/// @brief Information queue for debug and error messages 
-	class DX12Info
-	{
-	public:
-		WIS_INLINE DX12Info();
-		WIS_INLINE ~DX12Info();
-		DX12Info(const DX12Info&) = delete;
-		DX12Info& operator=(const DX12Info&) = delete;
-	public:
-		WIS_INLINE [[nodiscard]] static uint64_t GetNumMessages()noexcept;
-		WIS_INLINE [[nodiscard]] static std::vector<DXGIMessage> GetMessages()noexcept;
-	private:
-		static inline winrt::com_ptr<IDXGIInfoQueue> info_queue{};
-	};
+    /// @brief Information queue for debug and error messages
+    class DX12Info
+    {
+    public:
+        WIS_INLINE DX12Info();
+        WIS_INLINE ~DX12Info();
+        DX12Info(const DX12Info &) = delete;
+        DX12Info &operator=(const DX12Info &) = delete;
+
+    public:
+        WIS_INLINE [[nodiscard]] static uint64_t GetNumMessages() noexcept;
+        WIS_INLINE [[nodiscard]] static std::vector<DXGIMessage> GetMessages() noexcept;
+
+    private:
+        static inline winrt::com_ptr<IDXGIInfoQueue> info_queue{};
+    };
 }
 
 #if defined(WISDOM_HEADER_ONLY)

--- a/wisdom/include/wisdom/dx12/dx12_pipeline_state.h
+++ b/wisdom/include/wisdom/dx12/dx12_pipeline_state.h
@@ -8,34 +8,36 @@
 
 WIS_EXPORT namespace wis
 {
-	class DX12PipelineState;
+    class DX12PipelineState;
 
-	template<>
-	class Internal<DX12PipelineState>
-	{
-	public:
-		Internal() = default;
-		Internal(winrt::com_ptr<ID3D12PipelineState> xpipeline) : pipeline(std::move(xpipeline)){}
-	public:
-		ID3D12PipelineState* GetPipeline()const noexcept{
-			return pipeline.get();
-		}
-	protected:
-		winrt::com_ptr<ID3D12PipelineState> pipeline;
-	};
-	
+    template<>
+    class Internal<DX12PipelineState>
+    {
+    public:
+        Internal() = default;
+        Internal(winrt::com_ptr<ID3D12PipelineState> xpipeline)
+            : pipeline(std::move(xpipeline)) { }
 
+    public:
+        ID3D12PipelineState *GetPipeline() const noexcept
+        {
+            return pipeline.get();
+        }
 
-	/// @brief Pipeline state object, holds the state of the pipeline
-	class DX12PipelineState : public QueryInternal<DX12PipelineState>
-	{
-	public:
-		DX12PipelineState() = default;
-		explicit DX12PipelineState(winrt::com_ptr<ID3D12PipelineState> xpipeline)
-			: QueryInternal(std::move(xpipeline)){}
-		operator DX12PipelineStateView()const noexcept{
-			return GetPipeline();
-		}
-	};
+    protected:
+        winrt::com_ptr<ID3D12PipelineState> pipeline;
+    };
 
+    /// @brief Pipeline state object, holds the state of the pipeline
+    class DX12PipelineState : public QueryInternal<DX12PipelineState>
+    {
+    public:
+        DX12PipelineState() = default;
+        explicit DX12PipelineState(winrt::com_ptr<ID3D12PipelineState> xpipeline)
+            : QueryInternal(std::move(xpipeline)) { }
+        operator DX12PipelineStateView() const noexcept
+        {
+            return GetPipeline();
+        }
+    };
 }

--- a/wisdom/include/wisdom/dx12/dx12_render_pass.h
+++ b/wisdom/include/wisdom/dx12/dx12_render_pass.h
@@ -10,54 +10,58 @@
 #include <vector>
 #endif
 
-
 WIS_EXPORT namespace wis
 {
-	class DX12RenderPass;
+    class DX12RenderPass;
 
-	template<>
-	class Internal<DX12RenderPass>
-	{
-	public:
-		Internal() = default;
-		Internal(wis::internals::uniform_allocator<DataFormat, max_render_targets> target_formats, 
-			std::vector<D3D12_RENDER_PASS_RENDER_TARGET_DESC> rt_descs, 
-			std::optional<D3D12_RENDER_PASS_DEPTH_STENCIL_DESC> ds_desc)
-			:target_formats(target_formats), rt_descs(std::move(rt_descs)), ds_desc(std::move(ds_desc))
-		{}
-	public:
-		std::span<D3D12_RENDER_PASS_RENDER_TARGET_DESC> GetRTDescs()const noexcept{
-			return rt_descs;
-		}
-		D3D12_RENDER_PASS_DEPTH_STENCIL_DESC* GetDSDesc()const noexcept {
-			return ds_desc.has_value() ? &ds_desc.value() : nullptr;
-		}
-		const wis::internals::uniform_allocator<DataFormat, max_render_targets> GetTargetFormats()const noexcept
-		{
-			return target_formats;
-		}
-		std::span<const DataFormat> GetTargetFormatSpan()const noexcept
-		{
-			return { target_formats.data(), target_formats.size() };
-		}
-	private:
-		wis::internals::uniform_allocator<DataFormat, max_render_targets> target_formats;
-		mutable std::vector<D3D12_RENDER_PASS_RENDER_TARGET_DESC> rt_descs;
-		mutable std::optional<D3D12_RENDER_PASS_DEPTH_STENCIL_DESC> ds_desc;
-	};
+    template<>
+    class Internal<DX12RenderPass>
+    {
+    public:
+        Internal() = default;
+        Internal(wis::internals::uniform_allocator<DataFormat, max_render_targets> target_formats,
+                 std::vector<D3D12_RENDER_PASS_RENDER_TARGET_DESC> rt_descs,
+                 std::optional<D3D12_RENDER_PASS_DEPTH_STENCIL_DESC> ds_desc)
+            : target_formats(target_formats), rt_descs(std::move(rt_descs)), ds_desc(std::move(ds_desc))
+        {
+        }
 
-	using DX12RenderPassView = const DX12RenderPass&; //rp is too large
+    public:
+        std::span<D3D12_RENDER_PASS_RENDER_TARGET_DESC> GetRTDescs() const noexcept
+        {
+            return rt_descs;
+        }
+        D3D12_RENDER_PASS_DEPTH_STENCIL_DESC *GetDSDesc() const noexcept
+        {
+            return ds_desc.has_value() ? &ds_desc.value() : nullptr;
+        }
+        const wis::internals::uniform_allocator<DataFormat, max_render_targets> GetTargetFormats() const noexcept
+        {
+            return target_formats;
+        }
+        std::span<const DataFormat> GetTargetFormatSpan() const noexcept
+        {
+            return { target_formats.data(), target_formats.size() };
+        }
 
-	// TODO: better RenderPass
-	class DX12RenderPass : public QueryInternal<DX12RenderPass>
-	{
-	public:
-		DX12RenderPass() = default;
-		explicit DX12RenderPass(wis::internals::uniform_allocator<DataFormat, max_render_targets> target_formats,
-			std::vector<D3D12_RENDER_PASS_RENDER_TARGET_DESC> rt_descs, 
-			std::optional<D3D12_RENDER_PASS_DEPTH_STENCIL_DESC> ds_desc = {})
-			:QueryInternal(target_formats, std::move(rt_descs), std::move(ds_desc))
-		{};
-	public:
-	};
+    private:
+        wis::internals::uniform_allocator<DataFormat, max_render_targets> target_formats;
+        mutable std::vector<D3D12_RENDER_PASS_RENDER_TARGET_DESC> rt_descs;
+        mutable std::optional<D3D12_RENDER_PASS_DEPTH_STENCIL_DESC> ds_desc;
+    };
+
+    using DX12RenderPassView = const DX12RenderPass &; // rp is too large
+
+    // TODO: better RenderPass
+    class DX12RenderPass : public QueryInternal<DX12RenderPass>
+    {
+    public:
+        DX12RenderPass() = default;
+        explicit DX12RenderPass(wis::internals::uniform_allocator<DataFormat, max_render_targets> target_formats,
+                                std::vector<D3D12_RENDER_PASS_RENDER_TARGET_DESC> rt_descs,
+                                std::optional<D3D12_RENDER_PASS_DEPTH_STENCIL_DESC> ds_desc = {})
+            : QueryInternal(target_formats, std::move(rt_descs), std::move(ds_desc)){};
+
+    public:
+    };
 }

--- a/wisdom/include/wisdom/dx12/dx12_resource.h
+++ b/wisdom/include/wisdom/dx12/dx12_resource.h
@@ -54,17 +54,17 @@ WIS_EXPORT namespace wis
             resource->Unmap(0, nullptr);
             return true;
         }
-        [[nodiscard]] std::span<std::byte> MapMemory()noexcept
+        [[nodiscard]] std::span<std::byte> MapMemory() noexcept
         {
             void *bytes = nullptr;
             if (!wis::succeded_weak(resource->Map(0, nullptr, &bytes)))
                 return {};
             return { (std::byte *)bytes, resource->GetDesc().Width };
         }
-        void UnmapMemory()noexcept
+        void UnmapMemory() noexcept
         {
-			resource->Unmap(0, nullptr);
-		}
+            resource->Unmap(0, nullptr);
+        }
 
         [[nodiscard]] DX12VertexBufferView GetVertexBufferView(uint32_t byte_stride)
         {

--- a/wisdom/include/wisdom/dx12/dx12_root_signature.h
+++ b/wisdom/include/wisdom/dx12/dx12_root_signature.h
@@ -8,33 +8,39 @@
 
 WIS_EXPORT namespace wis
 {
-	class DX12RootSignature;
+    class DX12RootSignature;
 
-	template<>
-	class Internal<DX12RootSignature>
-	{
-	public:
-		Internal() = default;
-		explicit Internal(winrt::com_ptr<ID3D12RootSignature> xroot)noexcept
-			: root(std::move(xroot))
-		{}
-	public:
-		[[nodiscard]]ID3D12RootSignature* GetRootSignature()const noexcept{
-			return root.get();
-		}
-	protected:
-		winrt::com_ptr<ID3D12RootSignature> root;
-	};
+    template<>
+    class Internal<DX12RootSignature>
+    {
+    public:
+        Internal() = default;
+        explicit Internal(winrt::com_ptr<ID3D12RootSignature> xroot) noexcept
+            : root(std::move(xroot))
+        {
+        }
 
-	class DX12RootSignature : public QueryInternal<DX12RootSignature>
-	{
-	public:
-		DX12RootSignature() = default;
-		explicit DX12RootSignature(winrt::com_ptr<ID3D12RootSignature> xroot)noexcept
-			: QueryInternal(std::move(xroot))
-		{}
-		operator DX12RootSignatureView()const noexcept{
-			return GetRootSignature();
-		}
-	};
+    public:
+        [[nodiscard]] ID3D12RootSignature *GetRootSignature() const noexcept
+        {
+            return root.get();
+        }
+
+    protected:
+        winrt::com_ptr<ID3D12RootSignature> root;
+    };
+
+    class DX12RootSignature : public QueryInternal<DX12RootSignature>
+    {
+    public:
+        DX12RootSignature() = default;
+        explicit DX12RootSignature(winrt::com_ptr<ID3D12RootSignature> xroot) noexcept
+            : QueryInternal(std::move(xroot))
+        {
+        }
+        operator DX12RootSignatureView() const noexcept
+        {
+            return GetRootSignature();
+        }
+    };
 }

--- a/wisdom/include/wisdom/dx12/dx12_rtv.h
+++ b/wisdom/include/wisdom/dx12/dx12_rtv.h
@@ -6,30 +6,31 @@
 
 WIS_EXPORT namespace wis
 {
-	class DX12RenderTargetView;
+    class DX12RenderTargetView;
 
-	template<>
-	class Internal<DX12RenderTargetView>
-	{
-	public:
-		Internal() = default;
-		Internal(CD3DX12_CPU_DESCRIPTOR_HANDLE handle)
-			:handle(handle){}
-	public:
-		auto GetHandle()const noexcept
-		{
-			return handle;
-		}
-	protected:
-		CD3DX12_CPU_DESCRIPTOR_HANDLE handle;
-	};
+    template<>
+    class Internal<DX12RenderTargetView>
+    {
+    public:
+        Internal() = default;
+        Internal(CD3DX12_CPU_DESCRIPTOR_HANDLE handle)
+            : handle(handle) { }
 
+    public:
+        auto GetHandle() const noexcept
+        {
+            return handle;
+        }
 
-	class DX12RenderTargetView : public QueryInternal<DX12RenderTargetView>
-	{
-	public:
-		DX12RenderTargetView() = default;
-		explicit DX12RenderTargetView(CD3DX12_CPU_DESCRIPTOR_HANDLE xhandle)
-			:QueryInternal(xhandle){}
-	};
+    protected:
+        CD3DX12_CPU_DESCRIPTOR_HANDLE handle;
+    };
+
+    class DX12RenderTargetView : public QueryInternal<DX12RenderTargetView>
+    {
+    public:
+        DX12RenderTargetView() = default;
+        explicit DX12RenderTargetView(CD3DX12_CPU_DESCRIPTOR_HANDLE xhandle)
+            : QueryInternal(xhandle) { }
+    };
 }

--- a/wisdom/include/wisdom/dx12/dx12_shader.h
+++ b/wisdom/include/wisdom/dx12/dx12_shader.h
@@ -6,46 +6,52 @@
 
 WIS_EXPORT namespace wis
 {
-	class DX12Shader;
+    class DX12Shader;
 
-	template<>
-	class Internal<DX12Shader>
-	{
-	public:
-		Internal() = default;
-		Internal(shared_blob blob) :bytecode(std::move(blob)) {};
-	public:
-		[[nodiscard]]std::span<const std::byte> GetShaderBytecode()const noexcept
-		{
-			return bytecode.span<std::byte>();
-		}
-	protected:
-		wis::shared_blob bytecode;
-	};
+    template<>
+    class Internal<DX12Shader>
+    {
+    public:
+        Internal() = default;
+        Internal(shared_blob blob)
+            : bytecode(std::move(blob)){};
 
+    public:
+        [[nodiscard]] std::span<const std::byte> GetShaderBytecode() const noexcept
+        {
+            return bytecode.span<std::byte>();
+        }
 
-	/// @brief Shader object
-	class DX12Shader : public QueryInternal<DX12Shader>
-	{
-	public:
-		static constexpr inline ShaderLang language = ShaderLang::dxil;
-	public:
-		DX12Shader() = default;
-		explicit DX12Shader(shared_blob blob, ShaderType type)
-			:QueryInternal(std::move(blob)), type(type)
-		{}
-		operator bool()const noexcept{
-			return type != ShaderType::unknown && !bytecode.empty();
-		}
-	public:
+    protected:
+        wis::shared_blob bytecode;
+    };
 
-		/// @brief Type of shader e.g vertex, fragment, compute
-		/// @return shader type
-		[[nodiscard]]
-		auto GetType()const noexcept{
-			return type;
-		}
-	public:
-		ShaderType type = ShaderType::unknown;
-	};
+    /// @brief Shader object
+    class DX12Shader : public QueryInternal<DX12Shader>
+    {
+    public:
+        static constexpr inline ShaderLang language = ShaderLang::dxil;
+
+    public:
+        DX12Shader() = default;
+        explicit DX12Shader(shared_blob blob, ShaderType type)
+            : QueryInternal(std::move(blob)), type(type)
+        {
+        }
+        operator bool() const noexcept
+        {
+            return type != ShaderType::unknown && !bytecode.empty();
+        }
+
+    public:
+        /// @brief Type of shader e.g vertex, fragment, compute
+        /// @return shader type
+        [[nodiscard]] auto GetType() const noexcept
+        {
+            return type;
+        }
+
+    public:
+        ShaderType type = ShaderType::unknown;
+    };
 }

--- a/wisdom/include/wisdom/dx12/dx12_state_builder.h
+++ b/wisdom/include/wisdom/dx12/dx12_state_builder.h
@@ -7,73 +7,79 @@
 #include <wisdom/util/small_allocator.h>
 #endif
 
-
 WIS_EXPORT namespace wis
 {
-	class DX12GraphicsPipelineDesc
-	{
-		friend class DX12Device;
-	public:
-		DX12GraphicsPipelineDesc(DX12RootSignature sig)noexcept
-			:sig(std::move(sig))
-		{}
-	public:
-		DX12GraphicsPipelineDesc& SetVS(DX12Shader vs)noexcept
-		{
-			this->vs = std::move(vs); return *this;
-		}
-		DX12GraphicsPipelineDesc& SetPS(DX12Shader ps)noexcept
-		{
-			this->ps = std::move(ps); return *this;
-		}
-		DX12GraphicsPipelineDesc& SetGS(DX12Shader gs)noexcept
-		{
-			this->gs = std::move(gs); return *this;
-		}
-		DX12GraphicsPipelineDesc& SetHS(DX12Shader hs)noexcept
-		{
-			this->hs = std::move(hs); return *this;
-		}
-		DX12GraphicsPipelineDesc& SetDS(DX12Shader ds)noexcept
-		{
-			this->ds = std::move(ds); return *this;
-		}
-		DX12GraphicsPipelineDesc& SetShader(DX12Shader shader)noexcept
-		{
-			using enum ShaderType;
-			switch (shader.GetType())
-			{
-			case vertex:
-				return SetVS(std::move(shader));
-			case pixel:
-				return SetPS(std::move(shader));
-			case geometry:
-				return SetGS(std::move(shader));
-			case hull:
-				return SetHS(std::move(shader));
-			case domain:
-				return SetDS(std::move(shader));
-			default:
-				break;
-			}
-			return *this;
-		}
-		DX12GraphicsPipelineDesc& SetRenderPass(DX12RenderPassView pass)noexcept
-		{
-			target_formats = pass.GetInternal().GetTargetFormats();
-			return *this;
-		}
+    class DX12GraphicsPipelineDesc
+    {
+        friend class DX12Device;
 
-	private:
-		DX12RootSignature sig;
-		DX12Shader vs;
-		DX12Shader ps;
-		DX12Shader gs;
-		DX12Shader hs;
-		DX12Shader ds;
+    public:
+        DX12GraphicsPipelineDesc(DX12RootSignature sig) noexcept
+            : sig(std::move(sig))
+        {
+        }
 
-		wis::internals::uniform_allocator<DataFormat, max_render_targets> target_formats;
-	};
+    public:
+        DX12GraphicsPipelineDesc &SetVS(DX12Shader vs) noexcept
+        {
+            this->vs = std::move(vs);
+            return *this;
+        }
+        DX12GraphicsPipelineDesc &SetPS(DX12Shader ps) noexcept
+        {
+            this->ps = std::move(ps);
+            return *this;
+        }
+        DX12GraphicsPipelineDesc &SetGS(DX12Shader gs) noexcept
+        {
+            this->gs = std::move(gs);
+            return *this;
+        }
+        DX12GraphicsPipelineDesc &SetHS(DX12Shader hs) noexcept
+        {
+            this->hs = std::move(hs);
+            return *this;
+        }
+        DX12GraphicsPipelineDesc &SetDS(DX12Shader ds) noexcept
+        {
+            this->ds = std::move(ds);
+            return *this;
+        }
+        DX12GraphicsPipelineDesc &SetShader(DX12Shader shader) noexcept
+        {
+            using enum ShaderType;
+            switch (shader.GetType()) {
+            case vertex:
+                return SetVS(std::move(shader));
+            case pixel:
+                return SetPS(std::move(shader));
+            case geometry:
+                return SetGS(std::move(shader));
+            case hull:
+                return SetHS(std::move(shader));
+            case domain:
+                return SetDS(std::move(shader));
+            default:
+                break;
+            }
+            return *this;
+        }
+        DX12GraphicsPipelineDesc &SetRenderPass(DX12RenderPassView pass) noexcept
+        {
+            target_formats = pass.GetInternal().GetTargetFormats();
+            return *this;
+        }
 
-	// TODO: Mesh and Compute pipelines
+    private:
+        DX12RootSignature sig;
+        DX12Shader vs;
+        DX12Shader ps;
+        DX12Shader gs;
+        DX12Shader hs;
+        DX12Shader ds;
+
+        wis::internals::uniform_allocator<DataFormat, max_render_targets> target_formats;
+    };
+
+    // TODO: Mesh and Compute pipelines
 }

--- a/wisdom/include/wisdom/dx12/dx12_swapchain.h
+++ b/wisdom/include/wisdom/dx12/dx12_swapchain.h
@@ -6,104 +6,106 @@
 #include <dxgi1_5.h>
 #endif
 
-
 WIS_EXPORT namespace wis
 {
-	class DX12SwapChain;
+    class DX12SwapChain;
 
-	template<>
-	class Internal<DX12SwapChain>
-	{
-		friend class DX12SwapChain;
-		static constexpr inline bool valid = true;
-	public:
-		Internal() = default;
-		Internal(winrt::com_ptr<IDXGISwapChain4> chain)
-			:chain(std::move(chain)){}
-	public:
-		[[nodiscard]] IDXGISwapChain4* GetSwapChain()const noexcept {
-			return chain.get();
-		}
-	protected:
-		winrt::com_ptr<IDXGISwapChain4> chain{};
-	};
+    template<>
+    class Internal<DX12SwapChain>
+    {
+        friend class DX12SwapChain;
+        static constexpr inline bool valid = true;
 
+    public:
+        Internal() = default;
+        Internal(winrt::com_ptr<IDXGISwapChain4> chain)
+            : chain(std::move(chain)) { }
 
-	/// @brief SwapChain implementation for DX12
-	class DX12SwapChain : public QueryInternal<DX12SwapChain>
-	{
-		friend class DX12Factory;
-	public:
-		DX12SwapChain() = default;
-		explicit DX12SwapChain(winrt::com_ptr<IDXGISwapChain4> xchain, uint32_t frame_count, bool stereo)
-			:QueryInternal(std::move(xchain)), stereo(stereo)
-		{
-			render_targets.reserve(frame_count);
-			for (uint32_t n = 0; n < frame_count; n++)
-			{
-				winrt::com_ptr<ID3D12Resource> rc;
-				wis::check_hresult(chain->GetBuffer(n, __uuidof(ID3D12Resource), rc.put_void()));
-				render_targets.emplace_back(std::move(rc), nullptr);
-			}
-		}
-	public:
+    public:
+        [[nodiscard]] IDXGISwapChain4 *GetSwapChain() const noexcept
+        {
+            return chain.get();
+        }
 
-		/// @brief Get the current image index in the swapchain
-		/// @return Index of the current image
-		[[nodiscard]] uint32_t GetNextIndex()const noexcept
-		{
-			return chain->GetCurrentBackBufferIndex();
-		}
+    protected:
+        winrt::com_ptr<IDXGISwapChain4> chain{};
+    };
 
-		/// @brief Get all the render targets in the swapchain
-		/// @return Span of render targets
-		[[nodiscard]] std::span<const DX12Buffer> GetRenderTargets()const noexcept
-		{
-			return render_targets;
-		}
+    /// @brief SwapChain implementation for DX12
+    class DX12SwapChain : public QueryInternal<DX12SwapChain>
+    {
+        friend class DX12Factory;
 
-		/// @brief Get the current render target in the swapchain
-		/// @return Buffer view of the current render target TODO: Make a texture view
-		[[nodiscard]] DX12BufferView GetBackBuffer()const noexcept
-		{
-			return render_targets[chain->GetCurrentBackBufferIndex()];
-		}
+    public:
+        DX12SwapChain() = default;
+        explicit DX12SwapChain(winrt::com_ptr<IDXGISwapChain4> xchain, uint32_t frame_count, bool stereo)
+            : QueryInternal(std::move(xchain)), stereo(stereo)
+        {
+            render_targets.reserve(frame_count);
+            for (uint32_t n = 0; n < frame_count; n++) {
+                winrt::com_ptr<ID3D12Resource> rc;
+                wis::check_hresult(chain->GetBuffer(n, __uuidof(ID3D12Resource), rc.put_void()));
+                render_targets.emplace_back(std::move(rc), nullptr);
+            }
+        }
 
-		/// @brief Present the swapchain
-		/// @return true if succeeded
-		bool Present()noexcept
-		{
-			return wis::succeded_weak(chain->Present(0, 0));
-		}
+    public:
+        /// @brief Get the current image index in the swapchain
+        /// @return Index of the current image
+        [[nodiscard]] uint32_t GetNextIndex() const noexcept
+        {
+            return chain->GetCurrentBackBufferIndex();
+        }
 
-		/// @brief Check if stereo is supported
-		/// @return true if stereo is supported
-		[[nodiscard]] bool StereoSupported()const noexcept
-		{
-			return stereo;
-		}
+        /// @brief Get all the render targets in the swapchain
+        /// @return Span of render targets
+        [[nodiscard]] std::span<const DX12Buffer> GetRenderTargets() const noexcept
+        {
+            return render_targets;
+        }
 
-		/// @brief Resize the swapchain
-		/// For the method to succeed, all swapchain buffers must be released first
-		/// @param width New width
-		/// @param height New height
-		/// @return true if succeeded
-		[[nodiscard]] bool Resize(uint32_t width, uint32_t height)noexcept
-		{
-			size_t current_size = render_targets.size();
-			render_targets.clear(); //release all resources
-			if (!wis::succeded(chain->ResizeBuffers(current_size, width, height, DXGI_FORMAT_UNKNOWN, 0)))
-				return false;
+        /// @brief Get the current render target in the swapchain
+        /// @return Buffer view of the current render target TODO: Make a texture view
+        [[nodiscard]] DX12BufferView GetBackBuffer() const noexcept
+        {
+            return render_targets[chain->GetCurrentBackBufferIndex()];
+        }
 
-			for (uint32_t n = 0; n < current_size; n++)
-			{
-				winrt::com_ptr<ID3D12Resource> rc;
-				wis::check_hresult(chain->GetBuffer(n, __uuidof(ID3D12Resource), rc.put_void()));
-				render_targets.emplace_back(std::move(rc), nullptr);
-			}
-		}
-	private:
-		std::vector<DX12Buffer> render_targets{}; //< Render targets
-		bool stereo = false; //< Stereo support
-	};
+        /// @brief Present the swapchain
+        /// @return true if succeeded
+        bool Present() noexcept
+        {
+            return wis::succeded_weak(chain->Present(0, 0));
+        }
+
+        /// @brief Check if stereo is supported
+        /// @return true if stereo is supported
+        [[nodiscard]] bool StereoSupported() const noexcept
+        {
+            return stereo;
+        }
+
+        /// @brief Resize the swapchain
+        /// For the method to succeed, all swapchain buffers must be released first
+        /// @param width New width
+        /// @param height New height
+        /// @return true if succeeded
+        [[nodiscard]] bool Resize(uint32_t width, uint32_t height) noexcept
+        {
+            size_t current_size = render_targets.size();
+            render_targets.clear(); // release all resources
+            if (!wis::succeded(chain->ResizeBuffers(current_size, width, height, DXGI_FORMAT_UNKNOWN, 0)))
+                return false;
+
+            for (uint32_t n = 0; n < current_size; n++) {
+                winrt::com_ptr<ID3D12Resource> rc;
+                wis::check_hresult(chain->GetBuffer(n, __uuidof(ID3D12Resource), rc.put_void()));
+                render_targets.emplace_back(std::move(rc), nullptr);
+            }
+        }
+
+    private:
+        std::vector<DX12Buffer> render_targets{}; //< Render targets
+        bool stereo = false; //< Stereo support
+    };
 }

--- a/wisdom/include/wisdom/dx12/dx12_views.h
+++ b/wisdom/include/wisdom/dx12/dx12_views.h
@@ -2,14 +2,14 @@
 #include <d3dx12/d3dx12_root_signature.h>
 
 struct IDXGIAdapter1;
-//struct ID3D12Device10;
-//struct ID3D12PipelineState;
-//struct ID3D12CommandQueue;
-//struct ID3D12Fence1;
-//struct ID3D12DescriptorHeap;
-//struct ID3D12GraphicsCommandList9;
-//struct ID3D12Resource;
-//struct ID3D12RootSignature;
+// struct ID3D12Device10;
+// struct ID3D12PipelineState;
+// struct ID3D12CommandQueue;
+// struct ID3D12Fence1;
+// struct ID3D12DescriptorHeap;
+// struct ID3D12GraphicsCommandList9;
+// struct ID3D12Resource;
+// struct ID3D12RootSignature;
 
 WIS_EXPORT namespace wis
 {
@@ -24,5 +24,5 @@ WIS_EXPORT namespace wis
     using DX12RootSignatureView = ID3D12RootSignature *;
 
     using DX12DescriptorSetView = std::tuple<CD3DX12_CPU_DESCRIPTOR_HANDLE, CD3DX12_CPU_DESCRIPTOR_HANDLE, uint32_t>;
-    using DX12DescriptorSetBindView = std::tuple<ID3D12DescriptorHeap*, D3D12_GPU_DESCRIPTOR_HANDLE>;
+    using DX12DescriptorSetBindView = std::tuple<ID3D12DescriptorHeap *, D3D12_GPU_DESCRIPTOR_HANDLE>;
 }

--- a/wisdom/include/wisdom/dx12/impl/dx12_adapter.inl
+++ b/wisdom/include/wisdom/dx12/impl/dx12_adapter.inl
@@ -1,21 +1,21 @@
 
 
-wis::AdapterDesc wis::DX12Adapter::GetDesc()const noexcept
+wis::AdapterDesc wis::DX12Adapter::GetDesc() const noexcept
 {
-	DXGI_ADAPTER_DESC1 desc;
-	adapter->GetDesc1(&desc);
+    DXGI_ADAPTER_DESC1 desc;
+    adapter->GetDesc1(&desc);
 
-	return AdapterDesc{
-		.description {winrt::to_string(desc.Description)},
-		.vendor_id = desc.VendorId,
-		.device_id = desc.DeviceId,
-		.subsys_id = desc.SubSysId,
-		.revision = desc.Revision,
+    return AdapterDesc{
+        .description{ winrt::to_string(desc.Description) },
+        .vendor_id = desc.VendorId,
+        .device_id = desc.DeviceId,
+        .subsys_id = desc.SubSysId,
+        .revision = desc.Revision,
 
-		.dedicated_video_memory = desc.DedicatedVideoMemory,
-		.dedicated_system_memory = desc.DedicatedSystemMemory,
-		.shared_system_memory = desc.SharedSystemMemory,
-		.adapter_id{reinterpret_cast<uint64_t&>(desc.AdapterLuid)},
-		.flags = AdapterFlags(desc.Flags)
-	};
+        .dedicated_video_memory = desc.DedicatedVideoMemory,
+        .dedicated_system_memory = desc.DedicatedSystemMemory,
+        .shared_system_memory = desc.SharedSystemMemory,
+        .adapter_id{ reinterpret_cast<uint64_t &>(desc.AdapterLuid) },
+        .flags = AdapterFlags(desc.Flags)
+    };
 }

--- a/wisdom/include/wisdom/dx12/impl/dx12_allocator.inl
+++ b/wisdom/include/wisdom/dx12/impl/dx12_allocator.inl
@@ -4,58 +4,58 @@
 
 wis::DX12ResourceAllocator::DX12ResourceAllocator(wis::DX12DeviceView device, wis::DX12AdapterView adapter)
 {
-	D3D12MA::ALLOCATOR_DESC desc{
-		.Flags = D3D12MA::ALLOCATOR_FLAGS::ALLOCATOR_FLAG_NONE,
-		.pDevice = device,
-		.PreferredBlockSize = 0,
-		.pAllocationCallbacks = nullptr,
-		.pAdapter = adapter
-	};
-	wis::check_hresult(D3D12MA::CreateAllocator(&desc, allocator.put()));
+    D3D12MA::ALLOCATOR_DESC desc{
+        .Flags = D3D12MA::ALLOCATOR_FLAGS::ALLOCATOR_FLAG_NONE,
+        .pDevice = device,
+        .PreferredBlockSize = 0,
+        .pAllocationCallbacks = nullptr,
+        .pAdapter = adapter
+    };
+    wis::check_hresult(D3D12MA::CreateAllocator(&desc, allocator.put()));
 }
 wis::DX12Buffer wis::DX12ResourceAllocator::CreatePersistentBuffer(size_t size, [[maybe_unused]] BufferFlags flags)
 {
-	using namespace river::flags;
-	winrt::com_ptr<ID3D12Resource> rc;
-	winrt::com_ptr<D3D12MA::Allocation> al;
-	auto desc = CD3DX12_RESOURCE_DESC1::Buffer(size);
-	D3D12MA::ALLOCATION_DESC all_desc = {};
-	all_desc.HeapType = D3D12_HEAP_TYPE_DEFAULT;
+    using namespace river::flags;
+    winrt::com_ptr<ID3D12Resource> rc;
+    winrt::com_ptr<D3D12MA::Allocation> al;
+    auto desc = CD3DX12_RESOURCE_DESC1::Buffer(size);
+    D3D12MA::ALLOCATION_DESC all_desc = {};
+    all_desc.HeapType = D3D12_HEAP_TYPE_DEFAULT;
 
-	D3D12_RESOURCE_STATES state = D3D12_RESOURCE_STATE_COPY_DEST;
+    D3D12_RESOURCE_STATES state = D3D12_RESOURCE_STATE_COPY_DEST;
 
-	allocator->CreateResource2(&all_desc, &desc,
-		state, nullptr,
-		al.put(), __uuidof(*rc), rc.put_void());
+    allocator->CreateResource2(&all_desc, &desc,
+                               state, nullptr,
+                               al.put(), __uuidof(*rc), rc.put_void());
 
-	return DX12Buffer{ std::move(rc), std::move(al) };
+    return DX12Buffer{ std::move(rc), std::move(al) };
 }
 wis::DX12Buffer wis::DX12ResourceAllocator::CreateUploadBuffer(size_t size)
 {
-	winrt::com_ptr<ID3D12Resource> rc;
-	winrt::com_ptr<D3D12MA::Allocation> al;
-	auto desc = CD3DX12_RESOURCE_DESC::Buffer(size);
-	D3D12MA::ALLOCATION_DESC all_desc = {};
-	all_desc.HeapType = D3D12_HEAP_TYPE_UPLOAD;
+    winrt::com_ptr<ID3D12Resource> rc;
+    winrt::com_ptr<D3D12MA::Allocation> al;
+    auto desc = CD3DX12_RESOURCE_DESC::Buffer(size);
+    D3D12MA::ALLOCATION_DESC all_desc = {};
+    all_desc.HeapType = D3D12_HEAP_TYPE_UPLOAD;
 
-	allocator->CreateResource(&all_desc, &desc,
-		D3D12_RESOURCE_STATE_GENERIC_READ, nullptr,
-		al.put(), __uuidof(*rc), rc.put_void());
+    allocator->CreateResource(&all_desc, &desc,
+                              D3D12_RESOURCE_STATE_GENERIC_READ, nullptr,
+                              al.put(), __uuidof(*rc), rc.put_void());
 
-	return DX12Buffer{ std::move(rc), std::move(al) };
+    return DX12Buffer{ std::move(rc), std::move(al) };
 }
 
 wis::DX12Buffer wis::DX12ResourceAllocator::CreateHostVisibleBuffer(size_t size, [[maybe_unused]] BufferFlags flags) const
 {
-	winrt::com_ptr<ID3D12Resource> rc;
-	winrt::com_ptr<D3D12MA::Allocation> al;
-	auto desc = CD3DX12_RESOURCE_DESC::Buffer(size);
-	D3D12MA::ALLOCATION_DESC all_desc = {};
-	all_desc.HeapType = D3D12_HEAP_TYPE_UPLOAD;
+    winrt::com_ptr<ID3D12Resource> rc;
+    winrt::com_ptr<D3D12MA::Allocation> al;
+    auto desc = CD3DX12_RESOURCE_DESC::Buffer(size);
+    D3D12MA::ALLOCATION_DESC all_desc = {};
+    all_desc.HeapType = D3D12_HEAP_TYPE_UPLOAD;
 
-	allocator->CreateResource(&all_desc, &desc,
-		D3D12_RESOURCE_STATE_GENERIC_READ, nullptr,
-		al.put(), __uuidof(*rc), rc.put_void());
+    allocator->CreateResource(&all_desc, &desc,
+                              D3D12_RESOURCE_STATE_GENERIC_READ, nullptr,
+                              al.put(), __uuidof(*rc), rc.put_void());
 
-	return DX12Buffer{ std::move(rc), std::move(al) };
+    return DX12Buffer{ std::move(rc), std::move(al) };
 }

--- a/wisdom/include/wisdom/dx12/impl/dx12_checks.inl
+++ b/wisdom/include/wisdom/dx12/impl/dx12_checks.inl
@@ -2,46 +2,44 @@
 #include <wisdom/dx12/dx12_info.h>
 #endif
 
-bool wis::log_dxgi_errors()noexcept
+bool wis::log_dxgi_errors() noexcept
 {
-	using enum wis::Severity;
+    using enum wis::Severity;
 
-	if (!DX12Info::GetNumMessages())return false;
-	auto messages = DX12Info::GetMessages();
-	bool bError = false;
-	for (auto& i : messages)
-	{
-		bError |= i.severity == error || i.severity == critical;
-		lib_log(i.severity, i.description);
-	}
-	return bError;
+    if (!DX12Info::GetNumMessages())
+        return false;
+    auto messages = DX12Info::GetMessages();
+    bool bError = false;
+    for (auto &i : messages) {
+        bError |= i.severity == error || i.severity == critical;
+        lib_log(i.severity, i.description);
+    }
+    return bError;
 }
 
-winrt::hresult wis::last_windows_error()noexcept
+winrt::hresult wis::last_windows_error() noexcept
 {
-	return winrt::hresult(GetLastError());
+    return winrt::hresult(GetLastError());
 }
 
-//Window Exception
+// Window Exception
 wis::hr_exception::hr_exception(winrt::hresult hr, wis::source_location sl)
-	:exception(sl, false), hResult(hr)
+    : exception(sl, false), hResult(hr)
 {
-	log();
+    log();
 }
 std::string wis::hr_exception::description() const noexcept
 {
-	return winrt::to_string(winrt::to_hstring(hResult));
+    return winrt::to_string(winrt::to_hstring(hResult));
 }
-const char* wis::hr_exception::what() const noexcept
+const char *wis::hr_exception::what() const noexcept
 {
-	if (whatBuffer.empty())
-	{
-		whatBuffer = wis::format(
-			"{}\n[Error Code]: 0x{:08X}({})\n"
-			"[Description]: {}\n{}",
-			type(), (unsigned long)error_code(), (unsigned long)error_code(),
-			description(), origin()
-		);
-	}
-	return whatBuffer.c_str();
+    if (whatBuffer.empty()) {
+        whatBuffer = wis::format(
+                "{}\n[Error Code]: 0x{:08X}({})\n"
+                "[Description]: {}\n{}",
+                type(), (unsigned long)error_code(), (unsigned long)error_code(),
+                description(), origin());
+    }
+    return whatBuffer.c_str();
 }

--- a/wisdom/include/wisdom/dx12/impl/dx12_device.inl
+++ b/wisdom/include/wisdom/dx12/impl/dx12_device.inl
@@ -6,7 +6,7 @@ bool wis::DX12Device::Initialize(wis::DX12AdapterView adapter) noexcept
                                          D3D_FEATURE_LEVEL_11_0, __uuidof(ID3D12Device9), device.put_void())))
         return false;
 
-// Describe and create a render target view (RTV) descriptor heap.
+    // Describe and create a render target view (RTV) descriptor heap.
     D3D12_DESCRIPTOR_HEAP_DESC rtvHeapDesc = {};
     rtvHeapDesc.NumDescriptors = heap_size;
     rtvHeapDesc.Type = D3D12_DESCRIPTOR_HEAP_TYPE_RTV;
@@ -96,10 +96,8 @@ wis::DX12RootSignature wis::DX12Device::CreateRootSignature(std::span<DX12Descri
                 .InitAsDescriptorTable(ranges.size(), ranges.data(), D3D12_SHADER_VISIBILITY_ALL);
     }
 
-
     CD3DX12_VERSIONED_ROOT_SIGNATURE_DESC desc;
     desc.Init_1_1(uint32_t(root_parameters.size()), root_parameters.data(), 0, nullptr, flags);
-
 
     winrt::com_ptr<ID3DBlob> signature;
     winrt::com_ptr<ID3DBlob> error;
@@ -109,7 +107,7 @@ wis::DX12RootSignature wis::DX12Device::CreateRootSignature(std::span<DX12Descri
 }
 
 wis::DX12PipelineState wis::DX12Device::CreateGraphicsPipeline(
-        DX12GraphicsPipelineDesc desc,
+        const DX12GraphicsPipelineDesc &desc,
         std::span<const InputLayoutDesc> input_layout) const // movable
 {
     winrt::com_ptr<ID3D12PipelineState> state;

--- a/wisdom/include/wisdom/dx12/impl/dx12_factory.inl
+++ b/wisdom/include/wisdom/dx12/impl/dx12_factory.inl
@@ -5,140 +5,133 @@
 
 inline constexpr DXGI_GPU_PREFERENCE to_dxgi(wis::AdapterPreference pref)
 {
-	switch (pref)
-	{
-	default:
-	case wis::AdapterPreference::None:
-		return DXGI_GPU_PREFERENCE::DXGI_GPU_PREFERENCE_UNSPECIFIED;
-	case wis::AdapterPreference::MinConsumption:
-		return DXGI_GPU_PREFERENCE::DXGI_GPU_PREFERENCE_MINIMUM_POWER;
-	case wis::AdapterPreference::Performance:
-		return DXGI_GPU_PREFERENCE::DXGI_GPU_PREFERENCE_HIGH_PERFORMANCE;
-	}
+    switch (pref) {
+    default:
+    case wis::AdapterPreference::None:
+        return DXGI_GPU_PREFERENCE::DXGI_GPU_PREFERENCE_UNSPECIFIED;
+    case wis::AdapterPreference::MinConsumption:
+        return DXGI_GPU_PREFERENCE::DXGI_GPU_PREFERENCE_MINIMUM_POWER;
+    case wis::AdapterPreference::Performance:
+        return DXGI_GPU_PREFERENCE::DXGI_GPU_PREFERENCE_HIGH_PERFORMANCE;
+    }
 }
 
-wis::DX12Factory::DX12Factory(const ApplicationInfo& app_info, bool use_preference)
+wis::DX12Factory::DX12Factory(const ApplicationInfo &app_info, bool use_preference)
 {
-	if (factory)
-		return;
-	EnableDebugLayer();
-	wis::check_hresult(CreateDXGIFactory2(debug_flag,
-		__uuidof(IDXGIFactory4), factory.put_void()));
-	
-	// TODO: consider constexpr
+    if (factory)
+        return;
+    EnableDebugLayer();
+    wis::check_hresult(CreateDXGIFactory2(debug_flag,
+                                          __uuidof(IDXGIFactory4), factory.put_void()));
 
-	has_preference = bool(factory.try_as<IDXGIFactory6>()) && use_preference;
+    // TODO: consider constexpr
+
+    has_preference = bool(factory.try_as<IDXGIFactory6>()) && use_preference;
 }
 
-wis::generator<wis::DX12Adapter> wis::DX12Factory::EnumerateAdapters(wis::AdapterPreference preference)const noexcept
+wis::generator<wis::DX12Adapter> wis::DX12Factory::EnumerateAdapters(wis::AdapterPreference preference) const noexcept
 {
-	auto gen = has_preference ? AdaptersByGPUPreference(to_dxgi(preference)) : Adapters();
-	for (auto&& i : gen)
-		co_yield DX12Adapter(i);
+    auto gen = has_preference ? AdaptersByGPUPreference(to_dxgi(preference)) : Adapters();
+    for (auto &&i : gen)
+        co_yield DX12Adapter(i);
 }
 
 void wis::DX12Factory::EnableDebugLayer() noexcept
 {
-	if constexpr (wis::debug_mode) {
-		winrt::com_ptr<ID3D12Debug> debugController;
-		if (wis::succeded(D3D12GetDebugInterface(__uuidof(*debugController), debugController.put_void())))
-			debugController->EnableDebugLayer();
+    if constexpr (wis::debug_mode) {
+        winrt::com_ptr<ID3D12Debug> debugController;
+        if (wis::succeded(D3D12GetDebugInterface(__uuidof(*debugController), debugController.put_void())))
+            debugController->EnableDebugLayer();
 
-		if (auto d1 = debugController.try_as<ID3D12Debug1>())
-			d1->SetEnableGPUBasedValidation(true);
-	}
+        if (auto d1 = debugController.try_as<ID3D12Debug1>())
+            d1->SetEnableGPUBasedValidation(true);
+    }
 }
 
 wis::generator<winrt::com_ptr<IDXGIAdapter1>>
-wis::DX12Factory::AdaptersByGPUPreference(DXGI_GPU_PREFERENCE preference)const noexcept
+wis::DX12Factory::AdaptersByGPUPreference(DXGI_GPU_PREFERENCE preference) const noexcept
 {
-	winrt::com_ptr<IDXGIAdapter1> adapter;
-	auto factory6 = factory.try_as<IDXGIFactory6>();
-	uint32_t index = 0;
+    winrt::com_ptr<IDXGIAdapter1> adapter;
+    auto factory6 = factory.try_as<IDXGIFactory6>();
+    uint32_t index = 0;
 
-	while (wis::succeded_weak(factory6->EnumAdapterByGpuPreference(index++,
-		preference,
-		__uuidof(IDXGIAdapter1), adapter.put_void())))
-	{
-		co_yield std::move(adapter);
-	}
+    while (wis::succeded_weak(factory6->EnumAdapterByGpuPreference(index++,
+                                                                   preference,
+                                                                   __uuidof(IDXGIAdapter1), adapter.put_void()))) {
+        co_yield std::move(adapter);
+    }
 }
 
 wis::generator<winrt::com_ptr<IDXGIAdapter1>>
-wis::DX12Factory::Adapters()const noexcept
+wis::DX12Factory::Adapters() const noexcept
 {
-	winrt::com_ptr<IDXGIAdapter1> adapter;
-	uint32_t index = 0;
+    winrt::com_ptr<IDXGIAdapter1> adapter;
+    uint32_t index = 0;
 
-	while (wis::succeded_weak(factory->EnumAdapters1(index++, adapter.put())))
-		co_yield std::move(adapter);
+    while (wis::succeded_weak(factory->EnumAdapters1(index++, adapter.put())))
+        co_yield std::move(adapter);
 }
 
 inline winrt::com_ptr<ID3D11Device> CreateD3D11Device() noexcept
 {
-	constexpr D3D_FEATURE_LEVEL featureLevels[]
-	{
-		D3D_FEATURE_LEVEL_11_1,
-		D3D_FEATURE_LEVEL_11_0,
-		D3D_FEATURE_LEVEL_10_1
-	};
+    constexpr D3D_FEATURE_LEVEL featureLevels[]{
+        D3D_FEATURE_LEVEL_11_1,
+        D3D_FEATURE_LEVEL_11_0,
+        D3D_FEATURE_LEVEL_10_1
+    };
 
-	winrt::com_ptr<ID3D11Device> device11;
-	D3D11CreateDevice(nullptr,
-		D3D_DRIVER_TYPE_HARDWARE,
-		nullptr, 0,
-		featureLevels, 3, D3D11_SDK_VERSION, device11.put(), nullptr, nullptr);
-	return device11;
-}
-
-winrt::com_ptr<IDXGISwapChain4> 
-wis::DX12Factory::SwapChainForCoreWindow(const DXGI_SWAP_CHAIN_DESC1& desc, IUnknown* core_window, IUnknown* queue)
-{
-	winrt::com_ptr<IDXGISwapChain1> swap;
-	if (desc.Stereo) //until microsoft fixes this
-	{
-		wis::check_hresult(factory->CreateSwapChainForCoreWindow(
-			CreateD3D11Device().get(),
-			core_window,
-			&desc,
-			nullptr,
-			swap.put()
-		));
-	}
-
-	wis::check_hresult(factory->CreateSwapChainForCoreWindow(
-		queue,        // Swap chain needs the queue so that it can force a flush on it.
-		core_window,
-		&desc,
-		nullptr,
-		swap.put()
-	));
-	return swap.try_as<IDXGISwapChain4>();
+    winrt::com_ptr<ID3D11Device> device11;
+    D3D11CreateDevice(nullptr,
+                      D3D_DRIVER_TYPE_HARDWARE,
+                      nullptr, 0,
+                      featureLevels, 3, D3D11_SDK_VERSION, device11.put(), nullptr, nullptr);
+    return device11;
 }
 
 winrt::com_ptr<IDXGISwapChain4>
-wis::DX12Factory::SwapChainForWin32(const DXGI_SWAP_CHAIN_DESC1& desc, HWND hwnd, IUnknown* queue)
+wis::DX12Factory::SwapChainForCoreWindow(const DXGI_SWAP_CHAIN_DESC1 &desc, IUnknown *core_window, IUnknown *queue)
 {
-	winrt::com_ptr<IDXGISwapChain1> swap;
-	if (desc.Stereo) //until microsoft fixes this
-	{
-		wis::check_hresult(factory->CreateSwapChainForHwnd(
-			CreateD3D11Device().get(),        // Swap chain needs the queue so that it can force a flush on it.
-			hwnd,
-			&desc,
-			nullptr,
-			nullptr,
-			swap.put()
-		));
-	}
+    winrt::com_ptr<IDXGISwapChain1> swap;
+    if (desc.Stereo) // until microsoft fixes this
+    {
+        wis::check_hresult(factory->CreateSwapChainForCoreWindow(
+                CreateD3D11Device().get(),
+                core_window,
+                &desc,
+                nullptr,
+                swap.put()));
+    }
 
-	wis::check_hresult(factory->CreateSwapChainForHwnd(
-		queue,        // Swap chain needs the queue so that it can force a flush on it.
-		hwnd,
-		&desc,
-		nullptr,
-		nullptr,
-		swap.put()
-	));
-	return swap.try_as<IDXGISwapChain4>();
+    wis::check_hresult(factory->CreateSwapChainForCoreWindow(
+            queue, // Swap chain needs the queue so that it can force a flush on it.
+            core_window,
+            &desc,
+            nullptr,
+            swap.put()));
+    return swap.try_as<IDXGISwapChain4>();
+}
+
+winrt::com_ptr<IDXGISwapChain4>
+wis::DX12Factory::SwapChainForWin32(const DXGI_SWAP_CHAIN_DESC1 &desc, HWND hwnd, IUnknown *queue)
+{
+    winrt::com_ptr<IDXGISwapChain1> swap;
+    if (desc.Stereo) // until microsoft fixes this
+    {
+        wis::check_hresult(factory->CreateSwapChainForHwnd(
+                CreateD3D11Device().get(), // Swap chain needs the queue so that it can force a flush on it.
+                hwnd,
+                &desc,
+                nullptr,
+                nullptr,
+                swap.put()));
+    }
+
+    wis::check_hresult(factory->CreateSwapChainForHwnd(
+            queue, // Swap chain needs the queue so that it can force a flush on it.
+            hwnd,
+            &desc,
+            nullptr,
+            nullptr,
+            swap.put()));
+    return swap.try_as<IDXGISwapChain4>();
 }

--- a/wisdom/include/wisdom/dx12/impl/dx12_info.inl
+++ b/wisdom/include/wisdom/dx12/impl/dx12_info.inl
@@ -3,74 +3,70 @@
 #include <d3d12sdklayers.h>
 #endif
 
-inline constexpr wis::Severity Convert(DXGI_INFO_QUEUE_MESSAGE_SEVERITY sev)noexcept
+inline constexpr wis::Severity Convert(DXGI_INFO_QUEUE_MESSAGE_SEVERITY sev) noexcept
 {
-	using enum wis::Severity;
-	switch (sev)
-	{
-	default:
-	case DXGI_INFO_QUEUE_MESSAGE_SEVERITY_CORRUPTION:
-		return critical;
-	case DXGI_INFO_QUEUE_MESSAGE_SEVERITY_ERROR:
-		return error;
-	case DXGI_INFO_QUEUE_MESSAGE_SEVERITY_WARNING:
-		return warn;
-	case DXGI_INFO_QUEUE_MESSAGE_SEVERITY_INFO:
-		return info;
-	case DXGI_INFO_QUEUE_MESSAGE_SEVERITY_MESSAGE:
-		return debug;
-	}
+    using enum wis::Severity;
+    switch (sev) {
+    default:
+    case DXGI_INFO_QUEUE_MESSAGE_SEVERITY_CORRUPTION:
+        return critical;
+    case DXGI_INFO_QUEUE_MESSAGE_SEVERITY_ERROR:
+        return error;
+    case DXGI_INFO_QUEUE_MESSAGE_SEVERITY_WARNING:
+        return warn;
+    case DXGI_INFO_QUEUE_MESSAGE_SEVERITY_INFO:
+        return info;
+    case DXGI_INFO_QUEUE_MESSAGE_SEVERITY_MESSAGE:
+        return debug;
+    }
 }
-
 
 wis::DX12Info::DX12Info()
 {
-	winrt::check_hresult(DXGIGetDebugInterface1(0, __uuidof(IDXGIInfoQueue), info_queue.put_void()));
+    winrt::check_hresult(DXGIGetDebugInterface1(0, __uuidof(IDXGIInfoQueue), info_queue.put_void()));
 
-	if constexpr (debug_mode)
-	{
-		info_queue->SetBreakOnSeverity(DXGI_DEBUG_ALL, DXGI_INFO_QUEUE_MESSAGE_SEVERITY_ERROR, true);
-		info_queue->SetBreakOnSeverity(DXGI_DEBUG_ALL, DXGI_INFO_QUEUE_MESSAGE_SEVERITY_CORRUPTION, true);
-		info_queue->SetBreakOnSeverity(DXGI_DEBUG_ALL, DXGI_INFO_QUEUE_MESSAGE_SEVERITY_WARNING, true);
+    if constexpr (debug_mode) {
+        info_queue->SetBreakOnSeverity(DXGI_DEBUG_ALL, DXGI_INFO_QUEUE_MESSAGE_SEVERITY_ERROR, true);
+        info_queue->SetBreakOnSeverity(DXGI_DEBUG_ALL, DXGI_INFO_QUEUE_MESSAGE_SEVERITY_CORRUPTION, true);
+        info_queue->SetBreakOnSeverity(DXGI_DEBUG_ALL, DXGI_INFO_QUEUE_MESSAGE_SEVERITY_WARNING, true);
 
-		if (auto d3dinfoqueue = info_queue.try_as<ID3D12InfoQueue>())
-		{
-			d3dinfoqueue->SetBreakOnSeverity(D3D12_MESSAGE_SEVERITY_CORRUPTION, true); //Corruption
-			d3dinfoqueue->SetBreakOnSeverity(D3D12_MESSAGE_SEVERITY_ERROR, true); //Error
-			d3dinfoqueue->SetBreakOnSeverity(D3D12_MESSAGE_SEVERITY_WARNING, true); //Warning
-		}
-	}
+        if (auto d3dinfoqueue = info_queue.try_as<ID3D12InfoQueue>()) {
+            d3dinfoqueue->SetBreakOnSeverity(D3D12_MESSAGE_SEVERITY_CORRUPTION, true); // Corruption
+            d3dinfoqueue->SetBreakOnSeverity(D3D12_MESSAGE_SEVERITY_ERROR, true); // Error
+            d3dinfoqueue->SetBreakOnSeverity(D3D12_MESSAGE_SEVERITY_WARNING, true); // Warning
+        }
+    }
 }
 wis::DX12Info::~DX12Info()
 {
-	info_queue = nullptr;
+    info_queue = nullptr;
 }
-uint64_t wis::DX12Info::GetNumMessages()noexcept
+uint64_t wis::DX12Info::GetNumMessages() noexcept
 {
-	if (!info_queue)return 0;
-	return info_queue->GetNumStoredMessages(DXGI_DEBUG_ALL);
+    if (!info_queue)
+        return 0;
+    return info_queue->GetNumStoredMessages(DXGI_DEBUG_ALL);
 }
-std::vector<wis::DXGIMessage> wis::DX12Info::GetMessages()noexcept
+std::vector<wis::DXGIMessage> wis::DX12Info::GetMessages() noexcept
 {
-	if (!info_queue)return {};
-	std::vector<DXGIMessage> messages;
-	const auto end = info_queue->GetNumStoredMessages(DXGI_DEBUG_ALL);
-	if (!end)return{};
+    if (!info_queue)
+        return {};
+    std::vector<DXGIMessage> messages;
+    const auto end = info_queue->GetNumStoredMessages(DXGI_DEBUG_ALL);
+    if (!end)
+        return {};
 
-	for (UINT64 i = 0; i < end; i++)
-	{
-		SIZE_T messageLength = 0;
-		// get the size of message[i]
-		winrt::check_hresult(info_queue->GetMessage(DXGI_DEBUG_ALL, i, nullptr, &messageLength));
-		// allocate memory for message
-		auto bytes = std::make_unique<byte[]>(messageLength);
-		auto pMessage = reinterpret_cast<DXGI_INFO_QUEUE_MESSAGE*>(bytes.get());
-		// get message and bush it into vector
-		winrt::check_hresult(info_queue->GetMessage(DXGI_DEBUG_ALL, i, pMessage, &messageLength));
-		messages.emplace_back(Convert(pMessage->Severity), pMessage->pDescription);
-	}
-	info_queue->ClearStoredMessages(DXGI_DEBUG_ALL);
-	return messages;
+    for (UINT64 i = 0; i < end; i++) {
+        SIZE_T messageLength = 0;
+        // get the size of message[i]
+        winrt::check_hresult(info_queue->GetMessage(DXGI_DEBUG_ALL, i, nullptr, &messageLength));
+        // allocate memory for message
+        auto bytes = std::make_unique<byte[]>(messageLength);
+        auto pMessage = reinterpret_cast<DXGI_INFO_QUEUE_MESSAGE *>(bytes.get());
+        // get message and bush it into vector
+        winrt::check_hresult(info_queue->GetMessage(DXGI_DEBUG_ALL, i, pMessage, &messageLength));
+        messages.emplace_back(Convert(pMessage->Severity), pMessage->pDescription);
+    }
+    info_queue->ClearStoredMessages(DXGI_DEBUG_ALL);
+    return messages;
 }
-
-

--- a/wisdom/include/wisdom/global/assertions.h
+++ b/wisdom/include/wisdom/global/assertions.h
@@ -12,13 +12,11 @@ WIS_EXPORT class message_exception : public wis::exception
 public:
     message_exception(std::string message, wis::source_location sl = wis::source_location::current())
         : wis::exception(sl)
-		, m_message(message)
-	{
+        , m_message(std::move(message))
+    {
+    }
 
-	}
-
-public:
-    const char* what() const noexcept override
+    const char *what() const noexcept override
     {
         if (whatBuffer.empty()) {
             whatBuffer = wis::format(
@@ -45,9 +43,8 @@ private:
     std::string m_message;
 };
 
-
-#define WIS_ASSERT(b, message) ::wis::assert_debug(b, #b + message)
-inline void assert_debug(bool b, std::string_view message, wis::source_location sl = wis::source_location::current())noexcept
+#define WIS_ASSERT(b, message) ::wis::assert_debug(b, #b + (message))
+inline void assert_debug(bool b, std::string_view message, wis::source_location sl = wis::source_location::current()) noexcept
 {
     if constexpr (wis::debug_mode || wis::runtime_asserts)
         if (!b)

--- a/wisdom/include/wisdom/global/definitions.h
+++ b/wisdom/include/wisdom/global/definitions.h
@@ -3,9 +3,9 @@
 
 WIS_EXPORT namespace wis
 {
-	inline constexpr const bool debug_mode = DEBUG_MODE;
-	inline constexpr const bool runtime_asserts = RUNTIME_ASSERTS;
-	inline constexpr const unsigned max_render_targets = 8u;
-	inline constexpr const unsigned max_vertex_bindings = 16u;
-	inline constexpr const unsigned max_shader_stages = 5;
+    inline constexpr const bool debug_mode = DEBUG_MODE;
+    inline constexpr const bool runtime_asserts = RUNTIME_ASSERTS;
+    inline constexpr const unsigned max_render_targets = 8u;
+    inline constexpr const unsigned max_vertex_bindings = 16u;
+    inline constexpr const unsigned max_shader_stages = 5;
 }

--- a/wisdom/include/wisdom/shader_compiler.h
+++ b/wisdom/include/wisdom/shader_compiler.h
@@ -4,7 +4,7 @@
 //#include <dxc/dxcapi.h>
 //
 //
-//namespace wis
+// namespace wis
 //{
 //	//unfinished for linux
 //	class ShaderCompiler

--- a/wisdom/include/wisdom/util/exception.h
+++ b/wisdom/include/wisdom/util/exception.h
@@ -6,52 +6,53 @@
 #include <wisdom/util/log_layer.h>
 #endif // !WISDOM_MODULES
 
-
 WIS_EXPORT namespace wis
 {
-	class exception :std::exception
-	{
-	public:
-		exception(wis::source_location sl = wis::source_location::current(), bool write = true)noexcept
-			:sl(std::move(sl))
-		{
-			if (write)log();
-		}
+    class exception : std::exception
+    {
+    public:
+        exception(wis::source_location sl = wis::source_location::current(), bool write = true) noexcept
+            : sl(std::move(sl))
+        {
+            if (write)
+                log();
+        }
 
-	public:
-		void log()const noexcept
-		{
-			wis::lib_critical(what());
-		}
-		const char* what()const noexcept override
-		{
-			if (whatBuffer.empty())
-				whatBuffer = wis::format("{}\n{}", type(), origin());
-			return whatBuffer.c_str();
-		}
-		virtual std::string_view type()const noexcept
-		{
-			return "Veritas exception";
-		}
-		uint32_t line()const noexcept
-		{
-			return sl.line();
-		}
-		std::string_view file()const noexcept
-		{
-			return sl.file_name();
-		}
-		std::string_view function()const noexcept
-		{
-			return sl.function_name();
-		}
-		std::string origin()const noexcept
-		{
-			return wis::format("[File]: {}\n[Line]: {}\n[Function]: {}", file(), line(), function());
-		}
-	private:
-		wis::source_location sl;
-	protected:
-		mutable std::string whatBuffer;
-	};
+        void log() const noexcept
+        {
+            wis::lib_critical(what());
+        }
+        const char *what() const noexcept override
+        {
+            if (whatBuffer.empty())
+                whatBuffer = wis::format("{}\n{}", type(), origin());
+            return whatBuffer.c_str();
+        }
+        virtual std::string_view type() const noexcept
+        {
+            return "Veritas exception";
+        }
+        uint32_t line() const noexcept
+        {
+            return sl.line();
+        }
+        std::string_view file() const noexcept
+        {
+            return sl.file_name();
+        }
+        std::string_view function() const noexcept
+        {
+            return sl.function_name();
+        }
+        std::string origin() const noexcept
+        {
+            return wis::format("[File]: {}\n[Line]: {}\n[Function]: {}", file(), line(), function());
+        }
+
+    private:
+        wis::source_location sl;
+
+    protected:
+        mutable std::string whatBuffer;
+    };
 }

--- a/wisdom/include/wisdom/util/flags.h
+++ b/wisdom/include/wisdom/util/flags.h
@@ -23,94 +23,112 @@ SOFTWARE.
 #include <type_traits>
 #endif
 
-WIS_EXPORT namespace river::flags {
-    template <typename T>
+WIS_EXPORT namespace river::flags
+{
+    template<typename T>
     concept unsigned_enum = std::is_enum_v<T> && std::is_unsigned_v<std::underlying_type_t<T>>;
 
     namespace details {
-        template <unsigned_enum T>
-        constexpr bool is_flag() {
-            return true;
-        }
+    template<unsigned_enum T>
+    constexpr bool is_flag()
+    {
+        return true;
+    }
     } // namespace details
 
-    template <typename T>
+    template<typename T>
     concept Flag = unsigned_enum<T> && details::is_flag<T>();
 
-    template <Flag T>
-    constexpr auto underlying_value(T enum_value) {
+    template<Flag T>
+    constexpr auto underlying_value(T enum_value)
+    {
         return static_cast<std::underlying_type_t<T>>(enum_value);
     }
-    
-    template <Flag T>
-    constexpr auto operator+(T enum_value) {
+
+    template<Flag T>
+    constexpr auto operator+(T enum_value)
+    {
         return underlying_value(enum_value);
     }
 
-    template <Flag T>
-    constexpr auto operator~(T value) {
+    template<Flag T>
+    constexpr auto operator~(T value)
+    {
         return static_cast<std::underlying_type_t<T>>(~underlying_value(value));
     }
 
-    template <Flag T>
-    constexpr auto operator|(T lhs, T rhs) {
+    template<Flag T>
+    constexpr auto operator|(T lhs, T rhs)
+    {
         return static_cast<std::underlying_type_t<T>>(underlying_value(lhs) | underlying_value(rhs));
     }
-    template <Flag T>
-    constexpr auto operator|(std::underlying_type_t<T> lhs, T rhs) {
+    template<Flag T>
+    constexpr auto operator|(std::underlying_type_t<T> lhs, T rhs)
+    {
         return static_cast<std::underlying_type_t<T>>(lhs | underlying_value(rhs));
     }
-    template <Flag T>
-    constexpr auto operator|(T lhs, std::underlying_type_t<T> rhs) {
+    template<Flag T>
+    constexpr auto operator|(T lhs, std::underlying_type_t<T> rhs)
+    {
         return static_cast<std::underlying_type_t<T>>(underlying_value(lhs) | rhs);
     }
-    template <Flag T>
-    constexpr auto operator|=(std::underlying_type_t<T>& value, T const flag) {
+    template<Flag T>
+    constexpr auto operator|=(std::underlying_type_t<T> &value, T const flag)
+    {
         return value = value | flag;
     }
 
-    template <Flag T>
-    constexpr auto operator&(T lhs, T rhs) {
+    template<Flag T>
+    constexpr auto operator&(T lhs, T rhs)
+    {
         return static_cast<std::underlying_type_t<T>>(underlying_value(lhs) & underlying_value(rhs));
     }
-    template <Flag T>
-    constexpr auto operator&(std::underlying_type_t<T> lhs, T rhs) {
+    template<Flag T>
+    constexpr auto operator&(std::underlying_type_t<T> lhs, T rhs)
+    {
         return static_cast<std::underlying_type_t<T>>(lhs & underlying_value(rhs));
     }
-    template <Flag T>
-    constexpr auto operator&(T lhs, std::underlying_type_t<T> rhs) {
+    template<Flag T>
+    constexpr auto operator&(T lhs, std::underlying_type_t<T> rhs)
+    {
         return static_cast<std::underlying_type_t<T>>(underlying_value(lhs) & rhs);
     }
-    template <Flag T>
-    constexpr auto operator&=(std::underlying_type_t<T>& value, T const flag) {
+    template<Flag T>
+    constexpr auto operator&=(std::underlying_type_t<T> &value, T const flag)
+    {
         return value = value & flag;
     }
 
-    template <Flag T>
-    constexpr auto operator^(T lhs, T rhs) {
+    template<Flag T>
+    constexpr auto operator^(T lhs, T rhs)
+    {
         return static_cast<std::underlying_type_t<T>>(underlying_value(lhs) ^ underlying_value(rhs));
     }
-    template <Flag T>
-    constexpr auto operator^(std::underlying_type_t<T> lhs, T rhs) {
+    template<Flag T>
+    constexpr auto operator^(std::underlying_type_t<T> lhs, T rhs)
+    {
         return static_cast<std::underlying_type_t<T>>(lhs ^ underlying_value(rhs));
     }
-    template <Flag T>
-    constexpr auto operator^(T lhs, std::underlying_type_t<T> rhs) {
+    template<Flag T>
+    constexpr auto operator^(T lhs, std::underlying_type_t<T> rhs)
+    {
         return static_cast<std::underlying_type_t<T>>(underlying_value(lhs) ^ rhs);
     }
-    template <Flag T>
-    constexpr auto operator^=(std::underlying_type_t<T>& value, T const flag) {
+    template<Flag T>
+    constexpr auto operator^=(std::underlying_type_t<T> &value, T const flag)
+    {
         return value = value ^ flag;
     }
 
-
-    template <auto mask>
-    constexpr bool has(std::underlying_type_t<decltype(mask)> value) {
+    template<auto mask>
+    constexpr bool has(std::underlying_type_t<decltype(mask)> value)
+    {
         return (value & mask) == underlying_value(mask);
     }
 
     template<Flag T>
-    constexpr bool has(T lhs, T flag) {
+    constexpr bool has(T lhs, T flag)
+    {
         return (lhs & flag) == flag;
     }
 } // namespace river::flags

--- a/wisdom/include/wisdom/util/log_layer.h
+++ b/wisdom/include/wisdom/util/log_layer.h
@@ -8,158 +8,151 @@
 
 WIS_EXPORT namespace wis
 {
-	using river::flags::operator+;
+    using river::flags::operator+;
 
-	enum class Severity : uint8_t
-	{
-		debug,
-		trace,
-		info,
-		warn,
-		error,
-		critical
-	};
-	constexpr const char* severity_strings[]
-	{
-		"debug",
-		"trace",
-		"info",
-		"warn",
-		"error",
-		"critical"
-	};
+    enum class Severity : uint8_t {
+        debug,
+        trace,
+        info,
+        warn,
+        error,
+        critical
+    };
+    constexpr const char *severity_strings[]{
+        "debug",
+        "trace",
+        "info",
+        "warn",
+        "error",
+        "critical"
+    };
 
-	/// @brief Create a custom log layer to receive logging from the library
-	struct LogLayer
-	{
-		virtual ~LogLayer() = default;
-		virtual void Log(Severity sev, std::string message, wis::source_location sl = wis::source_location::current()) {};
-	};
+    /// @brief Create a custom log layer to receive logging from the library
+    struct LogLayer {
+        virtual ~LogLayer() = default;
+        virtual void Log(Severity sev, std::string message, wis::source_location sl = wis::source_location::current()){};
+    };
 
+    /// @brief Set the log layer for the library
+    class LibLogger
+    {
+        LibLogger() = default;
+        ~LibLogger() = default;
 
-	/// @brief Set the log layer for the library
-	class LibLogger
-	{
-		LibLogger() = default;
-		LibLogger(const LibLogger&) = delete;
-		LibLogger(LibLogger&&) = delete;
-		LibLogger& operator=(const LibLogger&) = delete;
-		LibLogger& operator=(LibLogger&&) = delete;
-		~LibLogger() = default;
-	public:
-		/// @brief Instance of the library logger
-		/// @return Instance of the library logger
-		[[nodiscard]]
-		static LibLogger& Instance()
-		{
-			static LibLogger log;
-			return log;
-		}
-	public:
-		/// @brief Set the log layer for the library
-		/// @param log Log layer
-		static void SetLogLayer(std::shared_ptr<LogLayer> log)noexcept
-		{
-			Instance().log = std::move(log);
-		}
+    public:
+        LibLogger(const LibLogger &) = delete;
+        LibLogger(LibLogger &&) = delete;
+        LibLogger &operator=(const LibLogger &) = delete;
+        LibLogger &operator=(LibLogger &&) = delete;
 
-		/// @brief Get the log layer for the library
-		/// @return Log layer
-		[[nodiscard]]
-		static auto* Get()noexcept
-		{
-			return Instance().log.get();
-		}
-	private:
-		std::shared_ptr<LogLayer> log{};
-	};
+        /// @brief Instance of the library logger
+        /// @return Instance of the library logger
+        [[nodiscard]] static LibLogger &Instance()
+        {
+            static LibLogger log;
+            return log;
+        }
 
+        /// @brief Set the log layer for the library
+        /// @param log Log layer
+        static void SetLogLayer(std::shared_ptr<LogLayer> log) noexcept
+        {
+            Instance().log = std::move(log);
+        }
 
+        /// @brief Get the log layer for the library
+        /// @return Log layer
+        [[nodiscard]] static auto *Get() noexcept
+        {
+            return Instance().log.get();
+        }
 
-	inline void lib_log_internal(Severity sev, std::string message, wis::source_location sl = wis::source_location::current())
-	{
-		if (auto log_ptr = LibLogger::Get())
-			log_ptr->Log(sev, std::move(message), sl);
-	}
+    private:
+        std::shared_ptr<LogLayer> log{};
+    };
 
+    inline void lib_log_internal(Severity sev, std::string message, wis::source_location sl = wis::source_location::current())
+    {
+        if (auto log_ptr = LibLogger::Get())
+            log_ptr->Log(sev, std::move(message), sl);
+    }
 
+    // Compile time resolved loggong for library
 
-	// Compile time resolved loggong for library
+    /// @brief Debug, this should be used for debugging purposes only
+    /// @param message Message text
+    /// @param sl Source location of the message
+    inline void lib_debug(std::string message, wis::source_location sl = wis::source_location::current())
+    {
+        if constexpr (WISDOM_LOG_LEVEL <= +Severity::debug)
+            lib_log_internal(Severity::debug, std::move(message), sl);
+    }
 
-	/// @brief Debug, this should be used for debugging purposes only
-	/// @param message Message text
-	/// @param sl Source location of the message
-	inline void lib_debug(std::string message, wis::source_location sl = wis::source_location::current())
-	{
-		if constexpr (WISDOM_LOG_LEVEL <= +Severity::debug)
-			lib_log_internal(Severity::debug, std::move(message), sl);
-	}
+    /// @brief Trace, this should be used for very detailed information
+    /// @param message Message text
+    /// @param sl Source location of the message
+    inline void lib_trace(std::string message, wis::source_location sl = wis::source_location::current())
+    {
+        if constexpr (WISDOM_LOG_LEVEL <= +Severity::trace)
+            lib_log_internal(Severity::trace, std::move(message), sl);
+    }
 
-	/// @brief Trace, this should be used for very detailed information
-	/// @param message Message text
-	/// @param sl Source location of the message
-	inline void lib_trace(std::string message, wis::source_location sl = wis::source_location::current())
-	{
-		if constexpr (WISDOM_LOG_LEVEL <= +Severity::trace)
-			lib_log_internal(Severity::trace, std::move(message), sl);
-	}
+    /// @brief Information, this should be used for general information
+    /// @param message Message text
+    /// @param sl Source location of the message
+    inline void lib_info(std::string message, wis::source_location sl = wis::source_location::current())
+    {
+        if constexpr (WISDOM_LOG_LEVEL <= +Severity::info)
+            lib_log_internal(Severity::info, std::move(message), sl);
+    }
 
-	/// @brief Information, this should be used for general information
-	/// @param message Message text
-	/// @param sl Source location of the message
-	inline void lib_info(std::string message, wis::source_location sl = wis::source_location::current())
-	{
-		if constexpr (WISDOM_LOG_LEVEL <= +Severity::info)
-			lib_log_internal(Severity::info, std::move(message), sl);
-	}
+    /// @brief Log a warning message to the library log layer
+    /// @param message Message text
+    /// @param sl Source location of the message
+    inline void lib_warn(std::string message, wis::source_location sl = wis::source_location::current())
+    {
+        if constexpr (WISDOM_LOG_LEVEL <= +Severity::warn)
+            lib_log_internal(Severity::warn, std::move(message), sl);
+    }
 
-	/// @brief Log a warning message to the library log layer
-	/// @param message Message text
-	/// @param sl Source location of the message
-	inline void lib_warn(std::string message, wis::source_location sl = wis::source_location::current())
-	{
-		if constexpr (WISDOM_LOG_LEVEL <= +Severity::warn)
-			lib_log_internal(Severity::warn, std::move(message), sl);
-	}
+    /// @brief Error, this should be used when the library is in a recoverable state
+    /// @param message Message text
+    /// @param sl Source location of the message
+    inline void lib_error(std::string message, wis::source_location sl = wis::source_location::current())
+    {
+        if constexpr (WISDOM_LOG_LEVEL <= +Severity::error)
+            lib_log_internal(Severity::error, std::move(message), sl);
+    }
 
-	/// @brief Error, this should be used when the library is in a recoverable state
-	/// @param message Message text
-	/// @param sl Source location of the message
-	inline void lib_error(std::string message, wis::source_location sl = wis::source_location::current())
-	{
-		if constexpr (WISDOM_LOG_LEVEL <= +Severity::error)
-			lib_log_internal(Severity::error, std::move(message), sl);
-	}
+    /// @brief Critical error, this should be used when the library is in an unrecoverable state
+    /// @param message Message text
+    /// @param sl Source location of the message
+    inline void lib_critical(std::string message, wis::source_location sl = wis::source_location::current())
+    {
+        if constexpr (WISDOM_LOG_LEVEL <= +Severity::critical)
+            lib_log_internal(Severity::critical, std::move(message), sl);
+    }
 
-	/// @brief Critical error, this should be used when the library is in an unrecoverable state
-	/// @param message Message text
-	/// @param sl Source location of the message
-	inline void lib_critical(std::string message, wis::source_location sl = wis::source_location::current())
-	{
-		if constexpr (WISDOM_LOG_LEVEL <= +Severity::critical)
-			lib_log_internal(Severity::critical, std::move(message), sl);
-	}
-
-	/// @brief Log a message to the library log layer
-	/// @param sev Severity of the message
-	/// @param message Message text
-	/// @param sl Source location of the message
-	inline void lib_log(Severity sev, std::string message, wis::source_location sl = wis::source_location::current())
-	{
-		switch (sev) {
-		case Severity::debug:
-			return lib_debug(message, sl);
-		case Severity::trace:
-			return lib_trace(message, sl);
-		case Severity::info:
-			return lib_info(message, sl);
-		case Severity::warn:
-			return lib_warn(message, sl);
-		case Severity::error:
-			return lib_error(message, sl);
-		default:
-		case Severity::critical:
-			return lib_critical(message, sl);
-		}
-	}
+    /// @brief Log a message to the library log layer
+    /// @param sev Severity of the message
+    /// @param message Message text
+    /// @param sl Source location of the message
+    inline void lib_log(Severity sev, std::string message, wis::source_location sl = wis::source_location::current())
+    {
+        switch (sev) {
+        case Severity::debug: // NOLINT
+            return lib_debug(message, sl);
+        case Severity::trace:
+            return lib_trace(message, sl);
+        case Severity::info:
+            return lib_info(message, sl);
+        case Severity::warn:
+            return lib_warn(message, sl);
+        case Severity::error:
+            return lib_error(message, sl);
+        default:
+        case Severity::critical:
+            return lib_critical(message, sl);
+        }
+    }
 }

--- a/wisdom/include/wisdom/util/misc.h
+++ b/wisdom/include/wisdom/util/misc.h
@@ -5,16 +5,19 @@
 
 WIS_EXPORT namespace wis
 {
-	struct string_hash {
-		using is_transparent = void;
-		[[nodiscard]] size_t operator()(const char* txt) const {
-			return std::hash<std::string_view>{}(txt);
-		}
-		[[nodiscard]] size_t operator()(std::string_view txt) const {
-			return std::hash<std::string_view>{}(txt);
-		}
-		[[nodiscard]] size_t operator()(const std::string& txt) const {
-			return std::hash<std::string>{}(txt);
-		}
-	};
+    struct string_hash {
+        using is_transparent = void;
+        [[nodiscard]] size_t operator()(const char *txt) const
+        {
+            return std::hash<std::string_view>{}(txt);
+        }
+        [[nodiscard]] size_t operator()(std::string_view txt) const
+        {
+            return std::hash<std::string_view>{}(txt);
+        }
+        [[nodiscard]] size_t operator()(const std::string &txt) const
+        {
+            return std::hash<std::string>{}(txt);
+        }
+    };
 }

--- a/wisdom/include/wisdom/util/small_allocator.h
+++ b/wisdom/include/wisdom/util/small_allocator.h
@@ -7,143 +7,143 @@
 
 WIS_EXPORT namespace wis::internals
 {
-	/// @brief Default size of the stack allocator
-	inline constexpr auto allocator_size = 1024u;
+    /// @brief Default size of the stack allocator
+    inline constexpr auto allocator_size = 1024u;
 
+    /// @brief A heterogenius memory pool that allocates objects of different types on stack
+    /// It can't be used to allocate objects of types that are not trivially destructible and can't be moved or copied, due to memory fixed nature
+    /// Not thread safe, used for small objects that are allocated frequently in a single function
+    /// Uses stack model of allocation
+    /// @tparam max_size Maximum size of the pool in bytes
+    template<size_t max_size = allocator_size>
+    class memory_pool
+    {
+    public:
+        constexpr memory_pool() = default;
+        memory_pool(const memory_pool &) = delete;
+        memory_pool(memory_pool &&) = delete;
 
-	/// @brief A heterogenius memory pool that allocates objects of different types on stack
-	/// It can't be used to allocate objects of types that are not trivially destructible and can't be moved or copied, due to memory fixed nature
-	/// Not thread safe, used for small objects that are allocated frequently in a single function
-	/// Uses stack model of allocation
-	/// @tparam max_size Maximum size of the pool in bytes
-	template<size_t max_size = allocator_size>
-	class memory_pool
-	{
-	public:
-		constexpr memory_pool() = default;
-		memory_pool(const memory_pool&) = delete;
-		memory_pool(memory_pool&&) = delete;
-	public:
-		/// @brief Allocates an object of type T in the allocator and returns a reference to it
-		/// @tparam T Type of the object to allocate
-		/// @tparam ...Args Argument types that constructor requires, deduced from the arguments
-		/// @param ...args Arguments to pass to the constructor
-		/// @return Reference to the allocated object
-		template<typename T, typename ...Args> requires std::is_trivially_destructible_v<T>
-		constexpr T& allocate(Args&&... args)noexcept
-		{
-			T* x = new(allocator.data() + byte_size)T(std::forward<Args>(args)...);
-			byte_size += sizeof(T);
-			assert(byte_size <= max_size);
-			return *x;
-		};
+        /// @brief Allocates an object of type T in the allocator and returns a reference to it
+        /// @tparam T Type of the object to allocate
+        /// @tparam ...Args Argument types that constructor requires, deduced from the arguments
+        /// @param ...args Arguments to pass to the constructor
+        /// @return Reference to the allocated object
+        template<typename T, typename... Args>
+        requires std::is_trivially_destructible_v<T>
+        constexpr T &allocate(Args &&...args) noexcept
+        {
+            T *x = new (allocator.data() + byte_size) T(std::forward<Args>(args)...);
+            byte_size += sizeof(T);
+            assert(byte_size <= max_size);
+            return *x;
+        };
 
-		/// @brief Returns a pointer to the allocator data as a pointer to type T
-		/// @tparam T Type of the pointer to return
-		/// @return Data pointer as a pointer to type T
-		template<typename T>
-		constexpr T* data() noexcept
-		{
-			return reinterpret_cast<T*>(allocator.data());
-		}
+        /// @brief Returns a pointer to the allocator data as a pointer to type T
+        /// @tparam T Type of the pointer to return
+        /// @return Data pointer as a pointer to type T
+        template<typename T>
+        constexpr T *data() noexcept
+        {
+            return reinterpret_cast<T *>(allocator.data());
+        }
 
-		/// @brief Returns a pointer to the allocator data as a pointer to const type T
-		/// @tparam T Type of the pointer to return
-		/// @return Data pointer as a pointer to const type T
-		template<typename T>
-		constexpr const T* data()const noexcept
-		{
-			return reinterpret_cast<const T*>(allocator.data());
-		}
+        /// @brief Returns a pointer to the allocator data as a pointer to const type T
+        /// @tparam T Type of the pointer to return
+        /// @return Data pointer as a pointer to const type T
+        template<typename T>
+        constexpr const T *data() const noexcept
+        {
+            return reinterpret_cast<const T *>(allocator.data());
+        }
 
-		/// @brief Get the size of the allocated data
-		/// @return Size of the allocated data in bytes
-		constexpr size_t size_bytes()const noexcept
-		{
-			return byte_size;
-		}
-	private:
-		alignas(void*)std::array<std::byte, max_size> allocator{};
-		size_t byte_size = 0;
-	};
+        /// @brief Get the size of the allocated data
+        /// @return Size of the allocated data in bytes
+        [[nodiscard]] constexpr size_t size_bytes() const noexcept
+        {
+            return byte_size;
+        }
 
+    private:
+        alignas(void *) std::array<std::byte, max_size> allocator{};
+        size_t byte_size = 0;
+    };
 
+    /// @brief A homogeneous allocator that allocates objects of the same type on stack
+    /// It can't be used to allocate objects of types that are not trivially destructible
+    /// Not thread safe, used for small objects that are allocated frequently in a single function
+    /// @tparam T Type of the object to allocate
+    /// @tparam max_size Size of the allocator in objects
+    template<class T, size_t max_size = 16> // NOLINT
+    class uniform_allocator : public std::array<T, max_size>
+    {
+        static_assert(std::is_trivially_destructible_v<T>, "Uniform allocator can't be used to allocate objects of types that are not trivially destructible");
 
-	/// @brief A homogenius allocator that allocates objects of the same type on stack
-	/// It can't be used to allocate objects of types that are not trivially destructible
-	/// Not thread safe, used for small objects that are allocated frequently in a single function
-	/// @tparam T Type of the object to allocate
-	/// @tparam max_size Size of the allocator in objects
-	template<class T, size_t max_size = 16>
-	class uniform_allocator : public std::array<T, max_size>
-	{
-		static_assert(std::is_trivially_destructible_v<T>, "Uniform allocator can't be used to allocate objects of types that are not trivially destructible");
-	public:
-		constexpr uniform_allocator() = default;
-	public:
+    public:
+        constexpr uniform_allocator() = default;
 
-		/// @brief Allocates an object of type T in the allocator and returns a reference to it
-		/// @tparam ...Args Argument types that constructor requires, deduced from the arguments
-		/// @param ...args Arguments to pass to the constructor
-		/// @return Reference to the allocated object
-		template<typename ...Args>
-		constexpr T& allocate(Args&&... args)noexcept
-		{
-			T* x = new(this->data() + rsize)T(std::forward<Args>(args)...);
-			rsize++;
-			assert(rsize <= max_size);
-			return *x;
-		};
+        /// @brief Allocates an object of type T in the allocator and returns a reference to it
+        /// @tparam ...Args Argument types that constructor requires, deduced from the arguments
+        /// @param ...args Arguments to pass to the constructor
+        /// @return Reference to the allocated object
+        template<typename... Args>
+        constexpr T &allocate(Args &&...args) noexcept
+        {
+            T *x = new (this->data() + rsize) T(std::forward<Args>(args)...);
+            rsize++;
+            assert(rsize <= max_size);
+            return *x;
+        };
 
-		/// @brief Returns a size of the allocated data
-		/// @return Size of the allocated data in objects
-		constexpr size_t size()const noexcept
-		{
-			return rsize;
-		}
+        /// @brief Returns a size of the allocated data
+        /// @return Size of the allocated data in objects
+        [[nodiscard]] constexpr size_t size() const noexcept
+        {
+            return rsize;
+        }
 
-		/// @brief Returns a capacity of the allocator
-		/// @return Capacity of the allocator in objects
-		constexpr size_t capacity()const noexcept
-		{
-			return max_size;
-		}
+        /// @brief Returns a capacity of the allocator
+        /// @return Capacity of the allocator in objects
+        [[nodiscard]] constexpr size_t capacity() const noexcept
+        {
+            return max_size;
+        }
 
-		/// @brief Returns a size of the allocated data in bytes
-		/// @return Size of the allocated data in bytes
-		constexpr size_t size_bytes()const noexcept
-		{
-			return rsize * sizeof(T);
-		}
+        /// @brief Returns a size of the allocated data in bytes
+        /// @return Size of the allocated data in bytes
+        [[nodiscard]] constexpr size_t size_bytes() const noexcept
+        {
+            return rsize * sizeof(T);
+        }
 
-		/// @brief Iterator to the beginning of the allocated data
-		/// @return Pointer to the beginning of the allocated data
-		auto* begin()noexcept
-		{
-			return this->data();
-		}
+        /// @brief Iterator to the beginning of the allocated data
+        /// @return Pointer to the beginning of the allocated data
+        auto *begin() noexcept
+        {
+            return this->data();
+        }
 
-		/// @brief Iterator to the end of the allocated data
-		/// @return Pointer to the end of the allocated data
-		auto* end()noexcept
-		{
-			return this->data() + rsize;
-		}
+        /// @brief Iterator to the end of the allocated data
+        /// @return Pointer to the end of the allocated data
+        auto *end() noexcept
+        {
+            return this->data() + rsize;
+        }
 
-		/// @brief Const iterator to the beginning of the allocated data
-		/// @return Const pointer to the beginning of the allocated data
-		const auto* begin()const noexcept
-		{
-			return this->data();
-		}
+        /// @brief Const iterator to the beginning of the allocated data
+        /// @return Const pointer to the beginning of the allocated data
+        const auto *begin() const noexcept
+        {
+            return this->data();
+        }
 
-		/// @brief Const iterator to the end of the allocated data
-		/// @return Const pointer to the end of the allocated data
-		const auto* end()const noexcept
-		{
-			return this->data() + rsize;
-		}
-	private:
-		size_t rsize = 0;
-	};
+        /// @brief Const iterator to the end of the allocated data
+        /// @return Const pointer to the end of the allocated data
+        const auto *end() const noexcept
+        {
+            return this->data() + rsize;
+        }
+
+    private:
+        size_t rsize = 0;
+    };
 }

--- a/wisdom/include/wisdom/vulkan/impl/.clang-tidy
+++ b/wisdom/include/wisdom/vulkan/impl/.clang-tidy
@@ -1,0 +1,5 @@
+---
+# this file primarily removes checks that would prevent us from doing math with
+# numbers like a normal person
+Checks: '-readability-implicit-bool-conversion'
+InheritParentConfig: true

--- a/wisdom/include/wisdom/vulkan/impl/vk_adapter.inl
+++ b/wisdom/include/wisdom/vulkan/impl/vk_adapter.inl
@@ -1,53 +1,52 @@
 #ifndef WISDOM_MODULES
-//#include <wisdom/vulkan/vk_adapter.h>
+// #include <wisdom/vulkan/vk_adapter.h>
 #include <wisdom/vulkan/vk_dynamic_loader.h>
 #include <span>
 #endif
 
-wis::AdapterDesc wis::VKAdapter::GetDesc()const noexcept
+wis::AdapterDesc wis::VKAdapter::GetDesc() const noexcept
 {
-	using namespace river::flags;
-	vk::PhysicalDeviceProperties2 properties;
-	vk::PhysicalDeviceIDProperties id_props;
-	properties.pNext = &id_props;
-	DynamicLoader::loader.vkGetPhysicalDeviceProperties2(adapter, reinterpret_cast<VkPhysicalDeviceProperties2*>(&properties));
+    using namespace river::flags;
+    vk::PhysicalDeviceProperties2 properties;
+    vk::PhysicalDeviceIDProperties id_props;
+    properties.pNext = &id_props;
+    DynamicLoader::loader.vkGetPhysicalDeviceProperties2(adapter, reinterpret_cast<VkPhysicalDeviceProperties2 *>(&properties));
 
-	auto& desc = properties.properties;
-	auto desc2 = adapter.getMemoryProperties();
+    auto &desc = properties.properties;
+    auto desc2 = adapter.getMemoryProperties();
 
-	uint64_t local_mem = 0;
-	uint64_t system_mem = 0;
-	std::span types{ desc2.memoryTypes.data(), desc2.memoryTypeCount };
-	for (auto& i : types)
-	{
-		if (i.propertyFlags & vk::MemoryPropertyFlagBits::eDeviceLocal &&
-			desc2.memoryHeaps[i.heapIndex].flags & vk::MemoryHeapFlagBits::eDeviceLocal)
-		{
-			local_mem = desc2.memoryHeaps[i.heapIndex].size;
-		}
+    uint64_t local_mem = 0;
+    uint64_t system_mem = 0;
+    std::span types{ desc2.memoryTypes.data(), desc2.memoryTypeCount };
+    for (auto &i : types) {
+        if (i.propertyFlags & vk::MemoryPropertyFlagBits::eDeviceLocal &&
+            desc2.memoryHeaps[i.heapIndex].flags & vk::MemoryHeapFlagBits::eDeviceLocal) {
+            local_mem = desc2.memoryHeaps[i.heapIndex].size;
+        }
 
-		if (i.propertyFlags & vk::MemoryPropertyFlagBits::eHostCoherent)
-		{
-			system_mem = desc2.memoryHeaps[i.heapIndex].size;
-		}
-		if (system_mem && local_mem)break;
-	}
+        if (i.propertyFlags & vk::MemoryPropertyFlagBits::eHostCoherent) {
+            system_mem = desc2.memoryHeaps[i.heapIndex].size;
+        }
+        if ((system_mem != 0u) && (local_mem != 0u))
+            break;
+    }
 
-	AdapterFlags flag{ AdapterFlags(+AdapterFlags::Remote && (uint32_t(desc.deviceType) & uint32_t(vk::PhysicalDeviceType::eVirtualGpu)))
-	| AdapterFlags(+AdapterFlags::Software && (uint32_t(desc.deviceType) & uint32_t(vk::PhysicalDeviceType::eCpu))) };
+    AdapterFlags flag{
+        AdapterFlags(((+AdapterFlags::Remote) != 0u) && ((uint32_t(desc.deviceType) & uint32_t(vk::PhysicalDeviceType::eVirtualGpu)) != 0u)) | AdapterFlags(((+AdapterFlags::Software) != 0u) && ((uint32_t(desc.deviceType) & uint32_t(vk::PhysicalDeviceType::eCpu)) != 0u))
+    };
 
-	std::string_view x = desc.deviceName;
-	return AdapterDesc{
-		.description{x.begin(), x.end()},
-		.vendor_id = desc.vendorID,
-		.device_id = desc.deviceID,
-		.subsys_id = desc.apiVersion,
-		.revision = desc.driverVersion,
+    std::string_view x = desc.deviceName;
+    return AdapterDesc{
+        .description{ x.begin(), x.end() },
+        .vendor_id = desc.vendorID,
+        .device_id = desc.deviceID,
+        .subsys_id = desc.apiVersion,
+        .revision = desc.driverVersion,
 
-		.dedicated_video_memory = local_mem,
-		.dedicated_system_memory = 0,
-		.shared_system_memory = system_mem,
-		.adapter_id = reinterpret_cast<uint64_t&>(id_props.deviceLUID),
-		.flags = flag
-	};
+        .dedicated_video_memory = local_mem,
+        .dedicated_system_memory = 0,
+        .shared_system_memory = system_mem,
+        .adapter_id = reinterpret_cast<uint64_t &>(id_props.deviceLUID),
+        .flags = flag
+    };
 }

--- a/wisdom/include/wisdom/vulkan/impl/vk_allocator.inl
+++ b/wisdom/include/wisdom/vulkan/impl/vk_allocator.inl
@@ -1,27 +1,26 @@
 #ifndef WISDOM_MODULES
-//#include <wisdom/vulkan/vk_allocator.h>
+// #include <wisdom/vulkan/vk_allocator.h>
 #include <wisdom/vulkan/vk_factory.h>
 #endif
 
-wis::VKResourceAllocator::VKResourceAllocator(VKDeviceView device, VKAdapterView adapter)
+wis::VKResourceAllocator::VKResourceAllocator(const VKDeviceView &device, VKAdapterView adapter)
 {
-	vma::AllocatorCreateInfo allocatorInfo
-	{
-		vma::AllocatorCreateFlags(0),
-		adapter,
-		device.get(),
-		0,
-		nullptr,
-		nullptr,
-		nullptr,
-		nullptr,
-		VKFactory::GetInstance(),
-		VKFactory::GetApiVer()
-	};
+    vma::AllocatorCreateInfo allocatorInfo{
+        vma::AllocatorCreateFlags(0),
+        adapter,
+        device.get(),
+        0,
+        nullptr,
+        nullptr,
+        nullptr,
+        nullptr,
+        VKFactory::GetInstance(),
+        VKFactory::GetApiVer()
+    };
 
-	vma::Allocator al;
-	
-	std::ignore = vma::createAllocator(&allocatorInfo, &al);
+    vma::Allocator al;
 
-	allocator = wis::shared_handle<vma::Allocator>{ al, std::move(device) };
+    std::ignore = vma::createAllocator(&allocatorInfo, &al);
+
+    allocator = wis::shared_handle<vma::Allocator>{ al, std::move(device) };
 }

--- a/wisdom/include/wisdom/vulkan/impl/vk_command_list.inl
+++ b/wisdom/include/wisdom/vulkan/impl/vk_command_list.inl
@@ -1,96 +1,92 @@
-//#include <wisdom/vulkan/vk_command_list.h>
+// #include <wisdom/vulkan/vk_command_list.h>
 #ifndef WISDOM_MODULES
 #include <wisdom/util/small_allocator.h>
 #include <wisdom/global/definitions.h>
 #endif
 
-void wis::VKCommandList::BufferBarrier(wis::BufferBarrier barrier, VKBufferView buffer)noexcept
+void wis::VKCommandList::BufferBarrier(wis::BufferBarrier barrier, VKBufferView buffer) noexcept
 {
-	auto acc_before = convert_vk(barrier.access_before);
-	auto acc_after = convert_vk(barrier.access_after);
+    auto acc_before = convert_vk(barrier.access_before);
+    auto acc_after = convert_vk(barrier.access_after);
 
-	if (!buffer || acc_before == acc_after)
-		return;
+    if (!buffer || acc_before == acc_after)
+        return;
 
-	vk::BufferMemoryBarrier desc
-	{
-		acc_before, acc_after, VK_QUEUE_FAMILY_IGNORED, VK_QUEUE_FAMILY_IGNORED, buffer, 0, VK_WHOLE_SIZE
-	};
-	command_list.pipelineBarrier(
-		vk::PipelineStageFlagBits::eAllCommands, vk::PipelineStageFlagBits::eAllCommands,
-		vk::DependencyFlagBits::eByRegion,
-		0, nullptr,
-		1, &desc, 0, nullptr);
+    vk::BufferMemoryBarrier desc{
+        acc_before, acc_after, VK_QUEUE_FAMILY_IGNORED, VK_QUEUE_FAMILY_IGNORED, buffer, 0, VK_WHOLE_SIZE
+    };
+    command_list.pipelineBarrier(
+            vk::PipelineStageFlagBits::eAllCommands, vk::PipelineStageFlagBits::eAllCommands,
+            vk::DependencyFlagBits::eByRegion,
+            0, nullptr,
+            1, &desc, 0, nullptr);
 }
 
-void wis::VKCommandList::TextureBarrier(wis::TextureBarrier barrier, VKTextureView texture)noexcept
+void wis::VKCommandList::TextureBarrier(wis::TextureBarrier barrier, VKTextureView texture) noexcept
 {
-	vk::ImageLayout vk_state_before = convert_vk(barrier.state_before);
-	vk::ImageLayout vk_state_after = convert_vk(barrier.state_after);
+    vk::ImageLayout vk_state_before = convert_vk(barrier.state_before);
+    vk::ImageLayout vk_state_after = convert_vk(barrier.state_after);
 
-	auto acc_before = convert_vk(barrier.access_before);
-	auto acc_after = convert_vk(barrier.access_after);
+    auto acc_before = convert_vk(barrier.access_before);
+    auto acc_after = convert_vk(barrier.access_after);
 
-	if (!texture.image || (vk_state_before == vk_state_after && acc_before == acc_after))
-		return;
+    if (!texture.image || (vk_state_before == vk_state_after && acc_before == acc_after))
+        return;
 
-	vk::ImageMemoryBarrier image_memory_barrier
-	{
-		acc_before,
-			acc_after,
-			vk_state_before,
-			vk_state_after,
-			VK_QUEUE_FAMILY_IGNORED,
-			VK_QUEUE_FAMILY_IGNORED,
-			texture.image,
-			convert_vk(barrier.range, texture.format)
-	};
-	command_list.pipelineBarrier(
-		vk::PipelineStageFlagBits::eAllCommands, vk::PipelineStageFlagBits::eAllCommands,
-		vk::DependencyFlagBits::eByRegion,
-		0, nullptr,
-		0, nullptr,
-		1, &image_memory_barrier);
+    vk::ImageMemoryBarrier image_memory_barrier{
+        acc_before,
+        acc_after,
+        vk_state_before,
+        vk_state_after,
+        VK_QUEUE_FAMILY_IGNORED,
+        VK_QUEUE_FAMILY_IGNORED,
+        texture.image,
+        convert_vk(barrier.range, texture.format)
+    };
+    command_list.pipelineBarrier(
+            vk::PipelineStageFlagBits::eAllCommands, vk::PipelineStageFlagBits::eAllCommands,
+            vk::DependencyFlagBits::eByRegion,
+            0, nullptr,
+            0, nullptr,
+            1, &image_memory_barrier);
 }
 
-void wis::VKCommandList::IASetVertexBuffers(std::span<const VKVertexBufferView> resources, uint32_t start_slot)noexcept
+void wis::VKCommandList::IASetVertexBuffers(std::span<const VKVertexBufferView> resources, uint32_t start_slot) noexcept
 {
-	assert(resources.size() <= 16);
-	std::array<vk::Buffer, 16> buffers{};
-	std::array<vk::DeviceSize, 16> strides{};
-	std::array<vk::DeviceSize, 16> sizes{};
-	constexpr static std::array<vk::DeviceSize, 16> offsets{};
+    static constexpr size_t max_expected_entries = 16;
+    assert(resources.size() <= max_expected_entries);
+    std::array<vk::Buffer, max_expected_entries> buffers{};
+    std::array<vk::DeviceSize, max_expected_entries> strides{};
+    std::array<vk::DeviceSize, max_expected_entries> sizes{};
+    constexpr static std::array<vk::DeviceSize, 16> offsets{};
 
-	for (size_t i = 0; i < resources.size(); i++)
-	{
-		auto& ii = resources[i].GetInternal();
+    for (size_t i = 0; i < resources.size(); i++) {
+        const auto &ii = resources[i].GetInternal();
 
-		buffers[i] = ii.GetBufferWeak();
-		sizes[i] = ii.SizeBytes();
-		strides[i] = ii.StrideBytes();
-	}
+        buffers[i] = ii.GetBufferWeak();
+        sizes[i] = ii.SizeBytes();
+        strides[i] = ii.StrideBytes();
+    }
 
-	command_list.bindVertexBuffers2(start_slot, uint32_t(resources.size()), buffers.data(), offsets.data(), sizes.data(), strides.data());
+    command_list.bindVertexBuffers2(start_slot, uint32_t(resources.size()), buffers.data(), offsets.data(), sizes.data(), strides.data());
 }
 
-void  wis::VKCommandList::BeginRenderPass(wis::VKRenderPassView rp,
-	std::span<const std::pair<VKRenderTargetView, ColorClear>> render_targets)noexcept
+void wis::VKCommandList::BeginRenderPass(wis::VKRenderPassView rp,
+                                         std::span<const std::pair<VKRenderTargetView, ColorClear>> render_targets) noexcept
 {
-	wis::internals::uniform_allocator<vk::ImageView, max_render_targets> image_views;
-	wis::internals::uniform_allocator<vk::ClearValue, max_render_targets> image_clear;
-	for (auto& i : render_targets)
-	{
-		image_views.allocate(i.first.GetInternal().GetImageView());
-		image_clear.allocate().setColor(i.second);
-	}
+    wis::internals::uniform_allocator<vk::ImageView, max_render_targets> image_views;
+    wis::internals::uniform_allocator<vk::ClearValue, max_render_targets> image_clear;
+    for (const auto &i : render_targets) {
+        image_views.allocate(i.first.GetInternal().GetImageView());
+        image_clear.allocate().setColor(i.second);
+    }
 
-	vk::RenderPassAttachmentBeginInfo attachment_begin_info
-	{
-		uint32_t(render_targets.size()),
-		image_views.data()
-	};
-	vk::RenderPassBeginInfo render_pass_info{
-		rp.pass, rp.frame, vk::Rect2D{{0,0},{rp.frame_size.width, rp.frame_size.height }}, uint32_t(image_clear.size()), image_clear.data(),&attachment_begin_info
-	};
-	command_list.beginRenderPass(render_pass_info, vk::SubpassContents::eInline);
+    vk::RenderPassAttachmentBeginInfo attachment_begin_info{
+        uint32_t(render_targets.size()),
+        image_views.data()
+    };
+    vk::RenderPassBeginInfo render_pass_info{
+        rp.pass, rp.frame, vk::Rect2D{ { 0, 0 }, { rp.frame_size.width, rp.frame_size.height } }, uint32_t(image_clear.size()), image_clear.data(), &attachment_begin_info
+    };
+    command_list.beginRenderPass(render_pass_info, vk::SubpassContents::eInline);
 }

--- a/wisdom/include/wisdom/vulkan/impl/vk_swapchain.inl
+++ b/wisdom/include/wisdom/vulkan/impl/vk_swapchain.inl
@@ -7,53 +7,54 @@ wis::VKSwapChain::VKSwapChain(wis::shared_handle<vk::SwapchainKHR> swap,
                               vk::SurfaceFormatKHR format,
                               vk::PresentModeKHR present_mode,
                               bool stereo)
-	:QueryInternal(std::move(swap), graphics_queue, format, present_mode)
-	, stereo(stereo)
-	, present_queue(std::move(present_queue))
-	,initialization(std::move(initialization))
+    : QueryInternal(std::move(swap), graphics_queue, format, present_mode)
+    , stereo(stereo)
+    , present_queue(std::move(present_queue))
+    , initialization(std::move(initialization))
 {
-	CreateImages();
+    CreateImages();
 }
 
-bool wis::VKSwapChain::Present()noexcept
+bool wis::VKSwapChain::Present() noexcept
 {
-	vk::Semaphore a = graphics_semaphore.get();
-	vk::SubmitInfo desc{
-		0u, nullptr, nullptr, 0u, nullptr, 1u, &a
-	};
-	graphics_queue.submit(desc); //finish all the work on graphics queue
+    vk::Semaphore a = graphics_semaphore.get();
+    vk::SubmitInfo desc{
+        0u, nullptr, nullptr, 0u, nullptr, 1u, &a
+    };
+    graphics_queue.submit(desc); // finish all the work on graphics queue
 
-	auto x = swap.get();
-	vk::PresentInfoKHR present_info{
-		1, &a, 1, &x, &present_index, nullptr
-	};
+    auto x = swap.get();
+    vk::PresentInfoKHR present_info{
+        1, &a, 1, &x, &present_index, nullptr
+    };
 
-	return wis::succeded(present_queue.GetInternal().GetQueue().presentKHR(&present_info)) &&
-		AquireNextIndex();
+    return wis::succeded(present_queue.GetInternal().GetQueue().presentKHR(&present_info)) &&
+            AquireNextIndex();
 }
 
-bool wis::VKSwapChain::AquireNextIndex()noexcept
+bool wis::VKSwapChain::AquireNextIndex() noexcept
 {
-	present_index = device.acquireNextImageKHR(swap.get(), std::numeric_limits<uint64_t>::max(), present_semaphore.get()).value;
+    present_index = device.acquireNextImageKHR(swap.get(), std::numeric_limits<uint64_t>::max(), present_semaphore.get()).value;
 
-	vk::SubmitInfo signal_submit_info = {};
-	signal_submit_info.pNext = nullptr;
-	signal_submit_info.waitSemaphoreCount = 1;
-	signal_submit_info.pWaitSemaphores = &present_semaphore.get();
-	vk::PipelineStageFlags waitDstStageMask = vk::PipelineStageFlagBits::eTransfer;
-	signal_submit_info.pWaitDstStageMask = &waitDstStageMask;
-	return wis::succeded(present_queue.GetInternal().GetQueue().submit(1, &signal_submit_info, {}));
+    vk::SubmitInfo signal_submit_info = {};
+    signal_submit_info.pNext = nullptr;
+    signal_submit_info.waitSemaphoreCount = 1;
+    signal_submit_info.pWaitSemaphores = &present_semaphore.get();
+    vk::PipelineStageFlags waitDstStageMask = vk::PipelineStageFlagBits::eTransfer;
+    signal_submit_info.pWaitDstStageMask = &waitDstStageMask;
+    return wis::succeded(present_queue.GetInternal().GetQueue().submit(1, &signal_submit_info, {}));
 }
 
-void wis::VKSwapChain::ReleaseSemaphore()noexcept
+void wis::VKSwapChain::ReleaseSemaphore() noexcept
 {
-	if (!present_semaphore)return;
-	auto queue = present_queue.GetInternal().GetQueue();
+    if (!present_semaphore)
+        return;
+    auto queue = present_queue.GetInternal().GetQueue();
 
-	vk::SubmitInfo signal_submit_info = {};
-	signal_submit_info.pNext = nullptr;
-	signal_submit_info.signalSemaphoreCount = 1;
-	signal_submit_info.pSignalSemaphores = &present_semaphore.get();
-	wis::succeded(queue.submit(1, &signal_submit_info, {}));
-	queue.waitIdle();
+    vk::SubmitInfo signal_submit_info = {};
+    signal_submit_info.pNext = nullptr;
+    signal_submit_info.signalSemaphoreCount = 1;
+    signal_submit_info.pSignalSemaphores = &present_semaphore.get();
+    wis::succeded(queue.submit(1, &signal_submit_info, {}));
+    queue.waitIdle();
 }

--- a/wisdom/include/wisdom/vulkan/vk_adapter.h
+++ b/wisdom/include/wisdom/vulkan/vk_adapter.h
@@ -5,51 +5,50 @@
 #include <wisdom/vulkan/vk_views.h>
 #endif // !WISDOM_MODULES
 
-
 WIS_EXPORT namespace wis
 {
-	class VKAdapter;
+    class VKAdapter;
 
-	template<>
-	class Internal<VKAdapter>
-	{
-	public:
-		Internal() = default;
-		Internal(vk::PhysicalDevice adapter)noexcept
-			:adapter(adapter) {}
-	public:
-		[[nodiscard]]
-		vk::PhysicalDevice GetAdapter()const noexcept
-		{
-			return adapter;
-		}
-	protected:
-		vk::PhysicalDevice adapter;
-	};
+    template<>
+    class Internal<VKAdapter>
+    {
+    public:
+        Internal() = default;
+        Internal(vk::PhysicalDevice adapter) noexcept
+            : adapter(adapter) { }
 
+        [[nodiscard]] vk::PhysicalDevice GetAdapter() const noexcept
+        {
+            return adapter;
+        }
 
-	/// @brief Vulkan physcial adapter
-	class VKAdapter : public QueryInternal<VKAdapter>
-	{
-	public:
-		VKAdapter() = default;
-		explicit VKAdapter(vk::PhysicalDevice adapter)
-			:QueryInternal(adapter)
-		{}
+    protected:
+        vk::PhysicalDevice adapter;
+    };
 
-		/// @brief Get the adapter internal view
-		/// @return Adapter internal view
-		/// @note Do not use the contents of a view directly unless you know what you are doing
-		operator VKAdapterView()const noexcept
-		{
-			return GetAdapter();
-		}
-	public:
-		/// @brief Get the adapter description
-		/// @return Adapter Description
-		/// @note This function is thread safe
-		[[nodiscard]] WIS_INLINE AdapterDesc GetDesc()const noexcept;
-	};
+    /// @brief Vulkan physcial adapter
+    class VKAdapter : public QueryInternal<VKAdapter>
+    {
+    public:
+        VKAdapter() = default;
+        explicit VKAdapter(vk::PhysicalDevice adapter)
+            : QueryInternal(adapter)
+        {
+        }
+
+        /// @brief Get the adapter internal view
+        /// @return Adapter internal view
+        /// @note Do not use the contents of a view directly unless you know what you are doing
+        operator VKAdapterView() const noexcept
+        {
+            return GetAdapter();
+        }
+
+        /// @brief Get the adapter description
+        /// @return Adapter Description
+        /// @note This function is thread safe
+        [[nodiscard]] WIS_INLINE AdapterDesc GetDesc() const noexcept;
+    };
 }
 
 #if defined(WISDOM_HEADER_ONLY)

--- a/wisdom/include/wisdom/vulkan/vk_allocator.h
+++ b/wisdom/include/wisdom/vulkan/vk_allocator.h
@@ -31,7 +31,6 @@ WIS_EXPORT namespace wis
         VKResourceAllocator() = default;
         WIS_INLINE VKResourceAllocator(VKDeviceView device, VKAdapterView adapter);
 
-    public:
         /// @brief Create a buffer that is persistently mapped to the GPU
         /// @param size Size of the buffer
         /// @param flags Type of buffer
@@ -81,17 +80,16 @@ WIS_EXPORT namespace wis
 
             return CreateBuffer(desc, alloc);
         }
-        
+
         /// @brief Create a constant buffer that is accessible by the CPU and GPU
         /// This function is equivalent to CreateHostVisibleBuffer, but ensures that the buffer size is 256 byte aligned in debug mode
         /// @param size Size of the buffer
         /// @return Buffer object
         [[nodiscard]] VKBuffer CreateConstantBuffer(size_t size) const
         {
-            wis::assert_debug(size % 256 == 0, wis::format("{} is nor 256 byte aligned", size));
+            wis::assert_debug(size % 256 == 0, wis::format("{} is not 256 byte aligned", size));
             return CreateHostVisibleBuffer(size, BufferFlags::ConstantBuffer);
         }
-
 
     private:
         [[nodiscard]] VKBuffer CreateBuffer(const vk::BufferCreateInfo &desc, const vma::AllocationCreateInfo &alloc_desc) const

--- a/wisdom/include/wisdom/vulkan/vk_allocator_handles.h
+++ b/wisdom/include/wisdom/vulkan/vk_allocator_handles.h
@@ -24,13 +24,13 @@ WIS_EXPORT namespace wis
         {
         }
 
-        const auto &getParent() const noexcept
+        [[nodiscard]] const auto &getParent() const noexcept
         {
             return getHeader().device;
         }
 
     protected:
-        static void internalDestroy(const AllocatorHeader &control, vma::Allocator handle) noexcept
+        static void internalDestroy(const AllocatorHeader & /*control*/, vma::Allocator handle) noexcept
         {
             handle.destroy();
         }
@@ -55,8 +55,7 @@ WIS_EXPORT namespace wis
         {
         }
 
-    public:
-        const auto &getAllocator() const noexcept
+        [[nodiscard]] const auto &getAllocator() const noexcept
         {
             return m_control->m_header.allocator;
         }

--- a/wisdom/include/wisdom/vulkan/vk_buffer_views.h
+++ b/wisdom/include/wisdom/vulkan/vk_buffer_views.h
@@ -6,47 +6,49 @@
 
 WIS_EXPORT namespace wis
 {
-	class VKVertexBufferView;
+    class VKVertexBufferView;
 
-	template<>
-	class Internal<VKVertexBufferView>
-	{
-	public:
-		Internal() = default;
-		Internal(vk::Buffer buffer,
-			vk::DeviceSize size_bytes,
-			vk::DeviceSize stride_bytes)
-			:buffer(buffer), size_bytes(size_bytes), stride_bytes(stride_bytes)
-		{}
-	public:
-		auto GetBufferWeak()const noexcept
-		{
-			return buffer;
-		}
-		vk::DeviceSize SizeBytes()const noexcept
-		{
-			return size_bytes;
-		}
-		vk::DeviceSize StrideBytes()const noexcept
-		{
-			return stride_bytes;
-		}
-	protected:
-		vk::Buffer buffer;
-		vk::DeviceSize size_bytes;
-		vk::DeviceSize stride_bytes;
-	};
+    template<>
+    class Internal<VKVertexBufferView>
+    {
+    public:
+        Internal() = default;
+        Internal(vk::Buffer buffer,
+                 vk::DeviceSize size_bytes,
+                 vk::DeviceSize stride_bytes)
+            : buffer(buffer), size_bytes(size_bytes), stride_bytes(stride_bytes)
+        {
+        }
 
-	/// @brief Vertex buffer view
-	class VKVertexBufferView : public QueryInternal<VKVertexBufferView>
-	{
-	public:
-		VKVertexBufferView() = default;
-		explicit VKVertexBufferView(vk::Buffer buffer,
-			vk::DeviceSize size_bytes,
-			vk::DeviceSize stride_bytes)
-			:QueryInternal(buffer, size_bytes, stride_bytes)
-		{
-		}
-	};
+        [[nodiscard]] auto GetBufferWeak() const noexcept
+        {
+            return buffer;
+        }
+        [[nodiscard]] vk::DeviceSize SizeBytes() const noexcept
+        {
+            return size_bytes;
+        }
+        [[nodiscard]] vk::DeviceSize StrideBytes() const noexcept
+        {
+            return stride_bytes;
+        }
+
+    protected:
+        vk::Buffer buffer;
+        vk::DeviceSize size_bytes;
+        vk::DeviceSize stride_bytes;
+    };
+
+    /// @brief Vertex buffer view
+    class VKVertexBufferView : public QueryInternal<VKVertexBufferView>
+    {
+    public:
+        VKVertexBufferView() = default;
+        explicit VKVertexBufferView(vk::Buffer buffer,
+                                    vk::DeviceSize size_bytes,
+                                    vk::DeviceSize stride_bytes)
+            : QueryInternal(buffer, size_bytes, stride_bytes)
+        {
+        }
+    };
 }

--- a/wisdom/include/wisdom/vulkan/vk_checks.h
+++ b/wisdom/include/wisdom/vulkan/vk_checks.h
@@ -3,13 +3,12 @@
 #include <vulkan/vulkan.hpp>
 #endif
 
-namespace wis
+namespace wis {
+/// @brief Check if a vulkan result is a success
+/// @param res Result to check
+/// @return True if the result is a success
+inline bool succeded(vk::Result res)
 {
-	/// @brief Check if a vulkan result is a success
-	/// @param res Result to check
-	/// @return True if the result is a success
-	inline bool succeded(vk::Result res)
-	{
-		return res == vk::Result::eSuccess;
-	}
+    return res == vk::Result::eSuccess;
 }
+} // namespace wis

--- a/wisdom/include/wisdom/vulkan/vk_command_list.h
+++ b/wisdom/include/wisdom/vulkan/vk_command_list.h
@@ -6,6 +6,7 @@
 #include <wisdom/vulkan/vk_buffer_views.h>
 #include <wisdom/vulkan/vk_rtv.h>
 #include <span>
+#include <utility>
 #endif
 
 WIS_EXPORT namespace wis
@@ -18,7 +19,7 @@ WIS_EXPORT namespace wis
     public:
         Internal() = default;
         Internal(wis::shared_handle<vk::CommandPool> allocator, vk::CommandBuffer command_list)
-            : allocator(std::move(allocator)), command_list(std::move(command_list)) { }
+            : allocator(std::move(allocator)), command_list(command_list) { }
 
     protected:
         wis::shared_handle<vk::CommandPool> allocator;
@@ -31,18 +32,17 @@ WIS_EXPORT namespace wis
     public:
         VKCommandList() = default;
         explicit VKCommandList(wis::shared_handle<vk::CommandPool> allocator, vk::CommandBuffer command_list)
-            : QueryInternal(std::move(allocator), std::move(command_list)) { }
+            : QueryInternal(std::move(allocator), command_list) { }
         operator VKCommandListView() const noexcept
         {
             return command_list;
         }
 
-    public:
         /// @brief Bind a pipeline to the command list
         /// @param xpipeline Pipeline to bind
         void SetPipeline(VKPipelineState xpipeline) noexcept
         {
-            pipeline = xpipeline;
+            pipeline = std::move(xpipeline);
         }
 
         /// @brief Reset the command list
@@ -122,8 +122,8 @@ WIS_EXPORT namespace wis
         void RSSetScissorRect(ScissorRect srect) noexcept
         {
             vk::Rect2D rect;
-            rect.offset.x = srect.left;
-            rect.offset.y = srect.top;
+            rect.offset.x = static_cast<int>(srect.left);
+            rect.offset.y = static_cast<int>(srect.top);
             rect.extent.width = srect.right;
             rect.extent.height = srect.bottom;
             command_list.setScissor(0, 1, &rect);
@@ -168,8 +168,8 @@ WIS_EXPORT namespace wis
         }
         void SetGraphicsDescriptorSet(VKRootSignatureView root) noexcept
         {
-			//nothing tbd
-		}
+            // nothing tbd
+        }
         void SetGraphicsDescriptorSet(VKRootSignatureView root, uint32_t RootParameterIndex, VKDescriptorSetBindView heap) noexcept
         {
             command_list.bindDescriptorSets(vk::PipelineBindPoint::eGraphics, root, RootParameterIndex, 1, &heap, 0, nullptr);

--- a/wisdom/include/wisdom/vulkan/vk_command_queue.h
+++ b/wisdom/include/wisdom/vulkan/vk_command_queue.h
@@ -7,69 +7,70 @@
 
 WIS_EXPORT namespace wis
 {
-	class VKCommandQueue;
+    class VKCommandQueue;
 
-	template<>
-	class Internal<VKCommandQueue>
-	{
-		static constexpr inline bool valid = true;
-	public:
-		Internal() = default;
-		Internal(vk::Queue queue):queue(queue){}
-	public:
-		auto GetQueue()const noexcept
-		{
-			return queue;
-		}
-	protected:
-		vk::Queue queue;
-	};
+    template<>
+    class Internal<VKCommandQueue>
+    {
+        static constexpr inline bool valid = true;
 
-	/// @brief A command queue is used to submit command lists to the GPU.
-	class VKCommandQueue : public QueryInternal<VKCommandQueue>
-	{
-	public:
-		VKCommandQueue() = default;
-		explicit VKCommandQueue(vk::Queue queue)
-			:QueryInternal(queue){}
-		operator VKCommandQueueView()const noexcept
-		{
-			return queue;
-		}
-	public:
-		/// @brief Execute a command list on the GPU.
-		/// @param list List to execute.
-		void ExecuteCommandList(VKCommandListView command_list)
-		{
-			vk::PipelineStageFlags wait_dst_stage_mask = vk::PipelineStageFlagBits::eAllCommands;
+    public:
+        Internal() = default;
+        Internal(vk::Queue queue)
+            : queue(queue) { }
 
-			vk::SubmitInfo submit_info = {};
-			submit_info.commandBufferCount = 1;
-			submit_info.pCommandBuffers = &command_list;
-			submit_info.pWaitDstStageMask = &wait_dst_stage_mask;
+        [[nodiscard]] auto GetQueue() const noexcept
+        {
+            return queue;
+        }
 
-			queue.submit(submit_info);
-		}
+    protected:
+        vk::Queue queue;
+    };
 
-		/// @brief Signal a fence with some value.
-		/// @param fence Fence to signal.
-		/// @param value Value to signal with.
-		/// @return true if call succeeded.
-		bool Signal(VKFenceView fence, uint64_t value)
-		{
-			vk::TimelineSemaphoreSubmitInfo submit
-			{
-				0,nullptr,1,&value
-			};
+    /// @brief A command queue is used to submit command lists to the GPU.
+    class VKCommandQueue : public QueryInternal<VKCommandQueue>
+    {
+    public:
+        VKCommandQueue() = default;
+        explicit VKCommandQueue(vk::Queue queue)
+            : QueryInternal(queue) { }
+        operator VKCommandQueueView() const noexcept
+        {
+            return queue;
+        }
 
-			vk::SubmitInfo info
-			{
-				0, nullptr,
-				nullptr, 0u,nullptr,
-				1, &fence,
-				&submit
-			};
-			return wis::succeded(queue.submit(1, &info, nullptr));
-		}
-	};
+        /// @brief Execute a command list on the GPU.
+        /// @param list List to execute.
+        void ExecuteCommandList(VKCommandListView command_list)
+        {
+            vk::PipelineStageFlags wait_dst_stage_mask = vk::PipelineStageFlagBits::eAllCommands;
+
+            vk::SubmitInfo submit_info = {};
+            submit_info.commandBufferCount = 1;
+            submit_info.pCommandBuffers = &command_list;
+            submit_info.pWaitDstStageMask = &wait_dst_stage_mask;
+
+            queue.submit(submit_info);
+        }
+
+        /// @brief Signal a fence with some value.
+        /// @param fence Fence to signal.
+        /// @param value Value to signal with.
+        /// @return true if call succeeded.
+        bool Signal(VKFenceView fence, uint64_t value)
+        {
+            vk::TimelineSemaphoreSubmitInfo submit{
+                0, nullptr, 1, &value
+            };
+
+            vk::SubmitInfo info{
+                0, nullptr,
+                nullptr, 0u, nullptr,
+                1, &fence,
+                &submit
+            };
+            return wis::succeded(queue.submit(1, &info, nullptr));
+        }
+    };
 }

--- a/wisdom/include/wisdom/vulkan/vk_descriptor_heap.h
+++ b/wisdom/include/wisdom/vulkan/vk_descriptor_heap.h
@@ -20,8 +20,7 @@ WIS_EXPORT namespace wis
         Internal(wis::shared_handle<vk::DescriptorSetLayout> layout)
             : layout(std::move(layout)){};
 
-    public:
-        auto GetDescriptorSetLayout() const noexcept
+        [[nodiscard]] auto GetDescriptorSetLayout() const noexcept
         {
             return layout.get();
         }
@@ -35,13 +34,12 @@ WIS_EXPORT namespace wis
     public:
         using QueryInternal::QueryInternal;
         operator VKDescriptorSetLayoutView() const noexcept
-		{
-			return GetDescriptorSetLayout();
-		}
+        {
+            return GetDescriptorSetLayout();
+        }
     };
 
     class VKDescriptorSet;
-
 
     template<>
     class Internal<VKDescriptorSet>
@@ -51,7 +49,6 @@ WIS_EXPORT namespace wis
         Internal(wis::shared_handle<vk::DescriptorSet> set)
             : set(std::move(set)){};
 
-    public:
         [[nodiscard]] auto GetDescriptorSet() const noexcept
         {
             return set.get();
@@ -81,8 +78,7 @@ WIS_EXPORT namespace wis
         Internal(wis::shared_handle<vk::DescriptorPool> pool)
             : pool(std::move(pool)){};
 
-    public:
-        auto GetDescriptorPool() const noexcept
+        [[nodiscard]] auto GetDescriptorPool() const noexcept
         {
             return pool.get();
         }
@@ -111,10 +107,9 @@ WIS_EXPORT namespace wis
             return GetDescriptorPool();
         }
 
-    public:
         VKDescriptorSet AllocateDescriptorSet(VKDescriptorSetLayoutView layout)
         {
-            auto &device = pool.getParent();
+            const auto &device = pool.getParent();
 
             vk::DescriptorSetAllocateInfo alloc_info{
                 pool.get(), 1u, &layout

--- a/wisdom/include/wisdom/vulkan/vk_dynamic_loader.h
+++ b/wisdom/include/wisdom/vulkan/vk_dynamic_loader.h
@@ -5,16 +5,14 @@
 
 WIS_EXPORT namespace wis
 {
-	struct DynamicLoader
-	{
-		using type = vk::DispatchLoaderDynamic;
-		static inline vk::DispatchLoaderDynamic loader{};
-		static inline bool init = false;
-	};
-	struct StaticLoader
-	{
-		using type = vk::DispatchLoaderStatic;
-		static inline vk::DispatchLoaderStatic loader{};
-		static inline constexpr bool init = true;
-	};
+    struct DynamicLoader {
+        using type = vk::DispatchLoaderDynamic;
+        static inline vk::DispatchLoaderDynamic loader{};
+        static inline bool init = false;
+    };
+    struct StaticLoader {
+        using type = vk::DispatchLoaderStatic;
+        static inline vk::DispatchLoaderStatic loader{};
+        static inline constexpr bool init = true;
+    };
 }

--- a/wisdom/include/wisdom/vulkan/vk_factory.h
+++ b/wisdom/include/wisdom/vulkan/vk_factory.h
@@ -59,7 +59,6 @@ WIS_EXPORT namespace wis
         /// @param unused
         WIS_INLINE VKFactory(const ApplicationInfo &app_info, [[maybe_unused]] bool unused = true);
 
-    public:
         /// @brief Enumerates all adapters on the system
         /// @param preference Preference to use when enumerating adapters, changes the order of the adapters
         /// @return coroutine that yields VKAdapter

--- a/wisdom/include/wisdom/vulkan/vk_fence.h
+++ b/wisdom/include/wisdom/vulkan/vk_fence.h
@@ -7,68 +7,68 @@
 
 WIS_EXPORT namespace wis
 {
-	class VKFence;
+    class VKFence;
 
-	template<>
-	class Internal<VKFence>
-	{
-	public:
-		Internal() = default;
-		Internal(wis::shared_handle<vk::Semaphore> fence)
-			:fence(std::move(fence)), device(this->fence.getParent().get()){ }
-	public:
-		vk::Semaphore GetFence()const noexcept
-		{
-			return fence.get();
-		}
-	protected:
-		wis::shared_handle<vk::Semaphore> fence;
-		vk::Device device; //little overhead for better performance
-	};
+    template<>
+    class Internal<VKFence>
+    {
+    public:
+        Internal() = default;
+        Internal(wis::shared_handle<vk::Semaphore> fence)
+            : fence(std::move(fence)), device(this->fence.getParent().get()) { }
 
+        [[nodiscard]] vk::Semaphore GetFence() const noexcept
+        {
+            return fence.get();
+        }
 
-	class VKFence : public QueryInternal<VKFence>
-	{
-	public:
-		VKFence() = default;
-		explicit VKFence(wis::shared_handle<vk::Semaphore> fence)
-			:QueryInternal(std::move(fence))
-		{}
-		operator VKFenceView()const noexcept
-		{
-			return GetFence();
-		}
-	public:
-		/// @brief Get the current value of the fence.
-		/// @return Value of the fence.
-		uint64_t GetCompletedValue()const noexcept
-		{
-			return device.getSemaphoreCounterValue(fence.get());
-		}
+    protected:
+        wis::shared_handle<vk::Semaphore> fence;
+        vk::Device device; // little overhead for better performance
+    };
 
-		/// @brief Wait for the fence to reach a certain value.
-		/// @param value Value to wait for.
-		/// @return Boolean indicating whether the fence reached the value.
-		bool Wait(uint64_t value)const noexcept
-		{
-			if (GetCompletedValue() >= value)
-				return true;
+    class VKFence : public QueryInternal<VKFence>
+    {
+    public:
+        VKFence() = default;
+        explicit VKFence(wis::shared_handle<vk::Semaphore> fence)
+            : QueryInternal(std::move(fence))
+        {
+        }
+        operator VKFenceView() const noexcept
+        {
+            return GetFence();
+        }
 
-			auto s = fence.get();
-			vk::SemaphoreWaitInfo waitInfo{{}, 1, & s, & value};
-			return succeded(device.waitSemaphores(waitInfo, std::numeric_limits<uint64_t>::max()));
-		}
+        /// @brief Get the current value of the fence.
+        /// @return Value of the fence.
+        [[nodiscard]] uint64_t GetCompletedValue() const noexcept
+        {
+            return device.getSemaphoreCounterValue(fence.get());
+        }
 
-		/// @brief Signal the fence from CPU.
-		/// @param value Value to signal.
-		void Signal(uint64_t value)noexcept
-		{
-			vk::SemaphoreSignalInfo signalInfo
-			{
-				fence.get(),
-				value
-			};
-			std::ignore = device.signalSemaphore(&signalInfo);
-		}
-	};
+        /// @brief Wait for the fence to reach a certain value.
+        /// @param value Value to wait for.
+        /// @return Boolean indicating whether the fence reached the value.
+        bool Wait(uint64_t value) const noexcept // NOLINT
+        {
+            if (GetCompletedValue() >= value)
+                return true;
+
+            auto s = fence.get();
+            vk::SemaphoreWaitInfo waitInfo{ {}, 1, &s, &value };
+            return succeded(device.waitSemaphores(waitInfo, std::numeric_limits<uint64_t>::max()));
+        }
+
+        /// @brief Signal the fence from CPU.
+        /// @param value Value to signal.
+        void Signal(uint64_t value) noexcept
+        {
+            vk::SemaphoreSignalInfo signalInfo{
+                fence.get(),
+                value
+            };
+            std::ignore = device.signalSemaphore(&signalInfo);
+        }
+    };
 }

--- a/wisdom/include/wisdom/vulkan/vk_format.h
+++ b/wisdom/include/wisdom/vulkan/vk_format.h
@@ -7,310 +7,314 @@
 #include <vulkan/vulkan.hpp>
 #endif
 
-namespace wis
+namespace wis {
+constexpr inline vk::Format vk_format_map[]{
+    vk::Format::eUndefined, // unknown = 0,
+    vk::Format::eR32G32B32A32Sfloat, // r32g32b32a32_typeless = 1,
+    vk::Format::eR32G32B32A32Sfloat, // r32g32b32a32_float = 1,
+    vk::Format::eR32G32B32A32Uint, // r32g32b32a32_uint = 3,
+    vk::Format::eR32G32B32A32Sint, // r32g32b32a32_sint = 4,
+    vk::Format::eR32G32B32Sfloat, // r32g32b32_typeless = 5,
+    vk::Format::eR32G32B32Sfloat, // r32g32b32_float = 6,
+    vk::Format::eR32G32B32Uint, // r32g32b32_uint = 7,
+    vk::Format::eR32G32B32Sint, // r32g32b32_sint = 8,
+
+    vk::Format::eR16G16B16A16Sfloat, // r16g16b16a16_typeless = 9,
+    vk::Format::eR16G16B16A16Sfloat, // r16g16b16a16_float = 10,
+    vk::Format::eR16G16B16A16Unorm, // r16g16b16a16_unorm = 11,
+    vk::Format::eR16G16B16A16Uint, // r16g16b16a16_uint = 12,
+    vk::Format::eR16G16B16A16Snorm, // r16g16b16a16_snorm = 13,
+    vk::Format::eR16G16B16A16Sint, // r16g16b16a16_sint = 14,
+
+    vk::Format::eR32G32Sfloat, // r32g32_typeless = 15,
+    vk::Format::eR32G32Sfloat, // r32g32_float = 16,
+    vk::Format::eR32G32Uint, // r32g32_uint = 17,
+    vk::Format::eR32G32Sint, // r32g32_sint = 18,
+
+    vk::Format::eUndefined, // r32g8x24_typeless = 19,
+    vk::Format::eUndefined, // d32_float_s8x24_uint = 20,
+    vk::Format::eUndefined, // r32_float_x8x24_typeless = 21,
+    vk::Format::eUndefined, // x32_typeless_g8x24_uint = 22,
+
+    vk::Format::eUndefined, // r10g10b10a2_typeless = 23,
+    vk::Format::eA2R10G10B10UnormPack32, // r10g10b10a2_unorm = 24,
+    vk::Format::eA2R10G10B10UintPack32, // r10g10b10a2_uint = 25,
+    vk::Format::eB10G11R11UfloatPack32, // r11g11b10_float = 26,
+
+    vk::Format::eUndefined, // r8g8b8a8_typeless = 27,
+    vk::Format::eR8G8B8A8Unorm, // r8g8b8a8_unorm = 28,
+    vk::Format::eR8G8B8A8Srgb, // r8g8b8a8_unorm_srgb = 29,
+    vk::Format::eR8G8B8A8Uint, // r8g8b8a8_uint = 30,
+    vk::Format::eR8G8B8A8Snorm, // r8g8b8a8_snorm = 31,
+    vk::Format::eR8G8B8A8Sint, // r8g8b8a8_sint = 32,
+
+    vk::Format::eUndefined, // r16g16_typeless = 33,
+    vk::Format::eR16G16Sfloat, // r16g16_float = 34,
+    vk::Format::eR16G16Unorm, // r16g16_unorm = 35,
+    vk::Format::eR16G16Uint, // r16g16_uint = 36,
+    vk::Format::eR16G16Snorm, // r16g16_snorm = 37,
+    vk::Format::eR16G16Sint, // r16g16_sint = 38,
+
+    vk::Format::eUndefined, // r32_typeless = 39,
+    vk::Format::eD32Sfloat, // d32_float = 40,
+    vk::Format::eR32Sfloat, // r32_float = 41,
+    vk::Format::eR32Uint, // r32_uint = 42,
+    vk::Format::eR32Sint, // r32_sint = 43,
+
+    vk::Format::eUndefined, // r24g8_typeless = 44,
+    vk::Format::eD24UnormS8Uint, // d24_unorm_s8_uint = 45,
+    vk::Format::eX8D24UnormPack32, // r24_unorm_x8_typeless = 46,
+    vk::Format::eUndefined, // x24_typeless_g8_uint = 47,
+
+    vk::Format::eUndefined, // r8g8_typeless = 48,
+    vk::Format::eR8G8Unorm, // r8g8_unorm = 49,
+    vk::Format::eR8G8Uint, // r8g8_uint = 50,
+    vk::Format::eR8G8Snorm, // r8g8_snorm = 51,
+    vk::Format::eR8G8Sint, // r8g8_sint = 52,
+
+    vk::Format::eR16Sfloat, // r16_typeless = 53,
+    vk::Format::eR16Sfloat, // r16_float = 54,
+    vk::Format::eD16Unorm, // d16_unorm = 55,
+    vk::Format::eR16Unorm, // r16_unorm = 56,
+    vk::Format::eR16Uint, // r16_uint = 57,
+    vk::Format::eR16Snorm, // r16_snorm = 58,
+    vk::Format::eR16Sint, // r16_sint = 59,
+
+    vk::Format::eUndefined, // r8_typeless = 60,
+    vk::Format::eR8Unorm, // r8_unorm = 61,
+    vk::Format::eR8Uint, // r8_uint = 62,
+    vk::Format::eR8Snorm, // r8_snorm = 63,
+    vk::Format::eR8Sint, // r8_sint = 64,
+
+    vk::Format::eUndefined, // a8_unorm = 65,
+    vk::Format::eUndefined, // r1_unorm = 66,
+    vk::Format::eUndefined, // r9g9b9e5_sharedexp = 67,
+    vk::Format::eUndefined, // r8g8_b8g8_unorm = 68,
+    vk::Format::eUndefined, // g8r8_g8b8_unorm = 69,
+    vk::Format::eUndefined, // bc1_typeless = 70,
+    vk::Format::eUndefined, // bc1_unorm = 71,
+    vk::Format::eUndefined, // bc1_unorm_srgb = 72,
+    vk::Format::eUndefined, // bc2_typeless = 73,
+    vk::Format::eUndefined, // bc2_unorm = 74,
+    vk::Format::eUndefined, // bc2_unorm_srgb = 75,
+    vk::Format::eUndefined, // bc3_typeless = 76,
+    vk::Format::eUndefined, // bc3_unorm = 77,
+    vk::Format::eUndefined, // bc3_unorm_srgb = 78,
+    vk::Format::eUndefined, // bc4_typeless = 79,
+    vk::Format::eUndefined, // bc4_unorm = 80,
+    vk::Format::eUndefined, // bc4_snorm = 81,
+    vk::Format::eUndefined, // bc5_typeless = 82,
+    vk::Format::eUndefined, // bc5_unorm = 83,
+    vk::Format::eUndefined, // bc5_snorm = 84,
+    vk::Format::eUndefined, // b5g6r5_unorm = 85,
+    vk::Format::eUndefined, // b5g5r5a1_unorm = 86,
+
+    vk::Format::eB8G8R8A8Unorm, // b8g8r8a8_unorm = 87,
+    vk::Format::eB8G8R8A8Unorm, // b8g8r8x8_unorm = 88,
+    vk::Format::eUndefined, // r10g10b10_xr_bias_a2_unorm = 89,
+    vk::Format::eUndefined, // b8g8r8a8_typeless = 90,
+    vk::Format::eB8G8R8A8Srgb, // b8g8r8a8_unorm_srgb = 91,
+    vk::Format::eUndefined, // b8g8r8x8_typeless = 92,
+    vk::Format::eB8G8R8A8Srgb, // b8g8r8x8_unorm_srgb = 93,
+
+    vk::Format::eUndefined, // bc6h_typeless = 94,
+    vk::Format::eUndefined, // bc6h_uf16 = 95,
+    vk::Format::eUndefined, // bc6h_sf16 = 96,
+    vk::Format::eUndefined, // bc7_typeless = 97,
+    vk::Format::eUndefined, // bc7_unorm = 98,
+    vk::Format::eUndefined, // bc7_unorm_srgb = 99,
+    vk::Format::eUndefined, // ayuv = 100,
+    vk::Format::eUndefined, // y410 = 101,
+    vk::Format::eUndefined, // y416 = 102,
+    vk::Format::eUndefined, // nv12 = 103,
+    vk::Format::eUndefined, // p010 = 104,
+    vk::Format::eUndefined, // p016 = 105,
+    vk::Format::eUndefined, // opaque_420 = 106,
+    vk::Format::eUndefined, // yuy2 = 107,
+    vk::Format::eUndefined, // y210 = 108,
+    vk::Format::eUndefined, // y216 = 109,
+    vk::Format::eUndefined, // nv11 = 110,
+    vk::Format::eUndefined, // ai44 = 111,
+    vk::Format::eUndefined, // ia44 = 112,
+    vk::Format::eUndefined, // p8 = 113,
+    vk::Format::eUndefined, // a8p8 = 114,
+    vk::Format::eUndefined, // b4g4r4a4_unorm = 115,
+
+    vk::Format::eUndefined, // p208 = 130,
+    vk::Format::eUndefined, // v208 = 131,
+    vk::Format::eUndefined, // v408 = 132,
+
+    vk::Format::eUndefined, // sampler_feedback_min_mip_opaque = 189,
+    vk::Format::eUndefined, // sampler_feedback_mip_region_used_opaque = 190,
+};
+
+inline constexpr vk::Format vk_format(wis::DataFormat df)
 {
-	constexpr inline vk::Format vk_format_map[]
-	{
-		vk::Format::eUndefined,//unknown = 0,
-		vk::Format::eR32G32B32A32Sfloat,//r32g32b32a32_typeless = 1,
-		vk::Format::eR32G32B32A32Sfloat,//r32g32b32a32_float = 1,
-		vk::Format::eR32G32B32A32Uint,//r32g32b32a32_uint = 3,
-		vk::Format::eR32G32B32A32Sint,//r32g32b32a32_sint = 4,
-		vk::Format::eR32G32B32Sfloat,//r32g32b32_typeless = 5,
-		vk::Format::eR32G32B32Sfloat,//r32g32b32_float = 6,
-		vk::Format::eR32G32B32Uint,//r32g32b32_uint = 7,
-		vk::Format::eR32G32B32Sint,//r32g32b32_sint = 8,
-
-		vk::Format::eR16G16B16A16Sfloat,//r16g16b16a16_typeless = 9,
-		vk::Format::eR16G16B16A16Sfloat,//r16g16b16a16_float = 10,
-		vk::Format::eR16G16B16A16Unorm,//r16g16b16a16_unorm = 11,
-		vk::Format::eR16G16B16A16Uint,//r16g16b16a16_uint = 12,
-		vk::Format::eR16G16B16A16Snorm,//r16g16b16a16_snorm = 13,
-		vk::Format::eR16G16B16A16Sint,//r16g16b16a16_sint = 14,
-
-		vk::Format::eR32G32Sfloat,//r32g32_typeless = 15,
-		vk::Format::eR32G32Sfloat,//r32g32_float = 16,
-		vk::Format::eR32G32Uint,//r32g32_uint = 17,
-		vk::Format::eR32G32Sint,//r32g32_sint = 18,
-
-		vk::Format::eUndefined,//r32g8x24_typeless = 19,
-		vk::Format::eUndefined,//d32_float_s8x24_uint = 20,
-		vk::Format::eUndefined,//r32_float_x8x24_typeless = 21,
-		vk::Format::eUndefined,//x32_typeless_g8x24_uint = 22,
-
-		vk::Format::eUndefined,//r10g10b10a2_typeless = 23,
-		vk::Format::eA2R10G10B10UnormPack32,//r10g10b10a2_unorm = 24,
-		vk::Format::eA2R10G10B10UintPack32,//r10g10b10a2_uint = 25,
-		vk::Format::eB10G11R11UfloatPack32,//r11g11b10_float = 26,
-
-		vk::Format::eUndefined,//r8g8b8a8_typeless = 27,
-		vk::Format::eR8G8B8A8Unorm,//r8g8b8a8_unorm = 28,
-		vk::Format::eR8G8B8A8Srgb,//r8g8b8a8_unorm_srgb = 29,
-		vk::Format::eR8G8B8A8Uint,//r8g8b8a8_uint = 30,
-		vk::Format::eR8G8B8A8Snorm,//r8g8b8a8_snorm = 31,
-		vk::Format::eR8G8B8A8Sint,//r8g8b8a8_sint = 32,
-
-		vk::Format::eUndefined,//r16g16_typeless = 33,
-		vk::Format::eR16G16Sfloat,//r16g16_float = 34,
-		vk::Format::eR16G16Unorm,//r16g16_unorm = 35,
-		vk::Format::eR16G16Uint,//r16g16_uint = 36,
-		vk::Format::eR16G16Snorm,//r16g16_snorm = 37,
-		vk::Format::eR16G16Sint,//r16g16_sint = 38,
-
-		vk::Format::eUndefined,//r32_typeless = 39,
-		vk::Format::eD32Sfloat,//d32_float = 40,
-		vk::Format::eR32Sfloat,//r32_float = 41,
-		vk::Format::eR32Uint,//r32_uint = 42,
-		vk::Format::eR32Sint,//r32_sint = 43,
-
-		vk::Format::eUndefined,//r24g8_typeless = 44,
-		vk::Format::eD24UnormS8Uint,//d24_unorm_s8_uint = 45,
-		vk::Format::eX8D24UnormPack32,//r24_unorm_x8_typeless = 46,
-		vk::Format::eUndefined,//x24_typeless_g8_uint = 47,
-
-		vk::Format::eUndefined,//r8g8_typeless = 48,
-		vk::Format::eR8G8Unorm,//r8g8_unorm = 49,
-		vk::Format::eR8G8Uint,//r8g8_uint = 50,
-		vk::Format::eR8G8Snorm,//r8g8_snorm = 51,
-		vk::Format::eR8G8Sint,//r8g8_sint = 52,
-
-		vk::Format::eR16Sfloat,//r16_typeless = 53,
-		vk::Format::eR16Sfloat,//r16_float = 54,
-		vk::Format::eD16Unorm,//d16_unorm = 55,
-		vk::Format::eR16Unorm,//r16_unorm = 56,
-		vk::Format::eR16Uint,//r16_uint = 57,
-		vk::Format::eR16Snorm,//r16_snorm = 58,
-		vk::Format::eR16Sint,//r16_sint = 59,
-
-		vk::Format::eUndefined,//r8_typeless = 60,
-		vk::Format::eR8Unorm,//r8_unorm = 61,
-		vk::Format::eR8Uint,//r8_uint = 62,
-		vk::Format::eR8Snorm,//r8_snorm = 63,
-		vk::Format::eR8Sint,//r8_sint = 64,
-
-		vk::Format::eUndefined,//a8_unorm = 65,
-		vk::Format::eUndefined,//r1_unorm = 66,
-		vk::Format::eUndefined,//r9g9b9e5_sharedexp = 67,
-		vk::Format::eUndefined,//r8g8_b8g8_unorm = 68,
-		vk::Format::eUndefined,//g8r8_g8b8_unorm = 69,
-		vk::Format::eUndefined,//bc1_typeless = 70,
-		vk::Format::eUndefined,//bc1_unorm = 71,
-		vk::Format::eUndefined,//bc1_unorm_srgb = 72,
-		vk::Format::eUndefined,//bc2_typeless = 73,
-		vk::Format::eUndefined,//bc2_unorm = 74,
-		vk::Format::eUndefined,//bc2_unorm_srgb = 75,
-		vk::Format::eUndefined,//bc3_typeless = 76,
-		vk::Format::eUndefined,//bc3_unorm = 77,
-		vk::Format::eUndefined,//bc3_unorm_srgb = 78,
-		vk::Format::eUndefined,//bc4_typeless = 79,
-		vk::Format::eUndefined,//bc4_unorm = 80,
-		vk::Format::eUndefined,//bc4_snorm = 81,
-		vk::Format::eUndefined,//bc5_typeless = 82,
-		vk::Format::eUndefined,//bc5_unorm = 83,
-		vk::Format::eUndefined,//bc5_snorm = 84,
-		vk::Format::eUndefined,//b5g6r5_unorm = 85,
-		vk::Format::eUndefined,//b5g5r5a1_unorm = 86,
-
-		vk::Format::eB8G8R8A8Unorm,//b8g8r8a8_unorm = 87,
-		vk::Format::eB8G8R8A8Unorm,//b8g8r8x8_unorm = 88,
-		vk::Format::eUndefined,//r10g10b10_xr_bias_a2_unorm = 89,
-		vk::Format::eUndefined,//b8g8r8a8_typeless = 90,
-		vk::Format::eB8G8R8A8Srgb,//b8g8r8a8_unorm_srgb = 91,
-		vk::Format::eUndefined,//b8g8r8x8_typeless = 92,
-		vk::Format::eB8G8R8A8Srgb,//b8g8r8x8_unorm_srgb = 93,
-
-		vk::Format::eUndefined,//bc6h_typeless = 94,
-		vk::Format::eUndefined,//bc6h_uf16 = 95,
-		vk::Format::eUndefined,//bc6h_sf16 = 96,
-		vk::Format::eUndefined,//bc7_typeless = 97,
-		vk::Format::eUndefined,//bc7_unorm = 98,
-		vk::Format::eUndefined,//bc7_unorm_srgb = 99,
-		vk::Format::eUndefined,//ayuv = 100,
-		vk::Format::eUndefined,//y410 = 101,
-		vk::Format::eUndefined,//y416 = 102,
-		vk::Format::eUndefined,//nv12 = 103,
-		vk::Format::eUndefined,//p010 = 104,
-		vk::Format::eUndefined,//p016 = 105,
-		vk::Format::eUndefined,//opaque_420 = 106,
-		vk::Format::eUndefined,//yuy2 = 107,
-		vk::Format::eUndefined,//y210 = 108,
-		vk::Format::eUndefined,//y216 = 109,
-		vk::Format::eUndefined,//nv11 = 110,
-		vk::Format::eUndefined,//ai44 = 111,
-		vk::Format::eUndefined,//ia44 = 112,
-		vk::Format::eUndefined,//p8 = 113,
-		vk::Format::eUndefined,//a8p8 = 114,
-		vk::Format::eUndefined,//b4g4r4a4_unorm = 115,
-
-		vk::Format::eUndefined,//p208 = 130,
-		vk::Format::eUndefined,//v208 = 131,
-		vk::Format::eUndefined,//v408 = 132,
-
-		vk::Format::eUndefined,//sampler_feedback_min_mip_opaque = 189,
-		vk::Format::eUndefined,//sampler_feedback_mip_region_used_opaque = 190,
-	};
-
-	inline constexpr vk::Format vk_format(wis::DataFormat df)
-	{
-		using namespace river::flags;
-		return vk_format_map[+df];
-	}
-
-	inline constexpr vk::ImageAspectFlags aspect_flags(vk::Format format)
-	{
-		switch (format)
-		{
-		case vk::Format::eD32SfloatS8Uint:
-		case vk::Format::eD24UnormS8Uint:
-		case vk::Format::eD16UnormS8Uint:
-			return vk::ImageAspectFlagBits::eDepth | vk::ImageAspectFlagBits::eStencil;
-		case vk::Format::eD16Unorm:
-		case vk::Format::eD32Sfloat:
-		case vk::Format::eX8D24UnormPack32:
-			return vk::ImageAspectFlagBits::eDepth;
-		case vk::Format::eS8Uint:
-			return vk::ImageAspectFlagBits::eStencil;
-		default:
-			return vk::ImageAspectFlagBits::eColor;
-		}
-	}
-
-
-	inline constexpr vk::Format convert_vk(wis::DataFormat df)
-	{
-		return vk_format(df);
-	}
-	inline constexpr vk::ImageLayout convert_vk(TextureState state)
-	{
-		using enum vk::ImageLayout;
-		using enum TextureState;
-		switch (state)
-		{
-		case Undefined:
-			return eUndefined;
-		default:
-		case Common:
-			return eGeneral;
-		case Read:
-			return eReadOnlyOptimal;
-		case RenderTarget:
-			return eColorAttachmentOptimal;
-		case DepthWrite:
-			return eDepthStencilAttachmentOptimal;
-		case DepthRead:
-			return eDepthStencilReadOnlyOptimal;
-		case ShaderResource:
-			return eShaderReadOnlyOptimal;
-		case CopySrc:
-			return eTransferSrcOptimal;
-		case CopyDst:
-			return eTransferDstOptimal;
-		case VRSSource:
-			return eFragmentShadingRateAttachmentOptimalKHR;
-		case VideoDecodeRead:
-			return eVideoDecodeSrcKHR;
-		case VideoDecodeWrite:
-			return eVideoDecodeDstKHR;
-		//case VideoEncodeRead:
-		//	return eVideoEncodeSrcKHR;
-		//case VideoEncodeWrite:
-		//	return eVideoEncodeDstKHR;
-		case Present:
-			return ePresentSrcKHR;
-		}
-	}
-	inline constexpr vk::AccessFlags convert_vk(ResourceAccess access)
-	{
-		using namespace river::flags;
-		uint32_t result{};
-		if (access == ResourceAccess::Common)return vk::AccessFlags(+vk::AccessFlagBits::eMemoryRead | +vk::AccessFlagBits::eMemoryWrite);
-		if (access & ResourceAccess::VertexBuffer)result |= VK_ACCESS_VERTEX_ATTRIBUTE_READ_BIT;
-		if (access & ResourceAccess::ConstantBuffer)result |= VK_ACCESS_UNIFORM_READ_BIT;
-		if (access & ResourceAccess::IndexBuffer)result |= VK_ACCESS_INDEX_READ_BIT;
-		if (access & ResourceAccess::RenderTarget)result |= VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT;
-		if (access & ResourceAccess::UnorderedAccess)result |= VK_ACCESS_SHADER_WRITE_BIT | VK_ACCESS_SHADER_READ_BIT;
-		if (access & ResourceAccess::DepthWrite)result |= VK_ACCESS_DEPTH_STENCIL_ATTACHMENT_WRITE_BIT;
-		if (access & ResourceAccess::DepthRead)result |= VK_ACCESS_DEPTH_STENCIL_ATTACHMENT_READ_BIT;
-		if (access & ResourceAccess::ShaderResource)result |= VK_ACCESS_SHADER_READ_BIT;
-		if (access & ResourceAccess::TransformFeedback)result |= VK_ACCESS_TRANSFORM_FEEDBACK_WRITE_BIT_EXT;
-		if (access & ResourceAccess::IndirectCommandRead)result |= VK_ACCESS_INDIRECT_COMMAND_READ_BIT;
-		if (access & ResourceAccess::CopySource)result |= VK_ACCESS_TRANSFER_READ_BIT;
-		if (access & ResourceAccess::CopyDest)result |= VK_ACCESS_TRANSFER_WRITE_BIT;
-		if (access & ResourceAccess::RayTracingRead)result |= VK_ACCESS_ACCELERATION_STRUCTURE_READ_BIT_KHR;
-		if (access & ResourceAccess::RayTracingWrite)result |= VK_ACCESS_ACCELERATION_STRUCTURE_WRITE_BIT_KHR;
-		if (access & ResourceAccess::VRSSource)result |= VK_ACCESS_FRAGMENT_SHADING_RATE_ATTACHMENT_READ_BIT_KHR;
-		if (access & ResourceAccess::NoAccess)result |= VK_ACCESS_NONE;
-		return vk::AccessFlags(result);
-	}
-	inline constexpr vk::ImageSubresourceRange convert_vk(wis::SubresourceRange range, vk::Format format)
-	{
-		return 	vk::ImageSubresourceRange{
-			aspect_flags(format),
-				range.base_mip,
-				range.extent_mips,
-				range.base_layer,
-				range.extent_layers
-		};
-	}
-
-
-	inline constexpr vk::AttachmentLoadOp convert(PassLoadOperation state)
-	{
-		switch (state)
-		{
-		case PassLoadOperation::load:
-			return vk::AttachmentLoadOp::eLoad;
-		case PassLoadOperation::clear:
-			return vk::AttachmentLoadOp::eClear;
-		case PassLoadOperation::discard:
-			return vk::AttachmentLoadOp::eDontCare;
-		}
-		assert(false);
-		return vk::AttachmentLoadOp::eLoad;
-	}
-	inline constexpr vk::PrimitiveTopology convert(wis::PrimitiveTopology topology)
-	{
-		using enum vk::PrimitiveTopology;
-		switch (topology)
-		{
-		default:
-		case wis::PrimitiveTopology::undefined:
-		case wis::PrimitiveTopology::trianglelist:
-			return eTriangleList;
-		case wis::PrimitiveTopology::pointlist:
-			return ePointList;
-		case wis::PrimitiveTopology::linelist:
-			return eLineList;
-		case wis::PrimitiveTopology::linestrip:
-			return eLineStrip;
-		case wis::PrimitiveTopology::trianglestrip:
-			return eTriangleStrip;
-		case wis::PrimitiveTopology::trianglefan:
-			return eTriangleFan;
-		case wis::PrimitiveTopology::linelist_adj:
-			return eLineListWithAdjacency;
-		case wis::PrimitiveTopology::linestrip_adj:
-			return eLineStripWithAdjacency;
-		case wis::PrimitiveTopology::trianglelist_adj:
-			return eTriangleListWithAdjacency;
-		case wis::PrimitiveTopology::trianglestrip_adj:
-			return eTriangleListWithAdjacency;
-		}
-	}
-	inline constexpr vk::AttachmentStoreOp convert(PassStoreOperation state)
-	{
-		switch (state)
-		{
-		case PassStoreOperation::store:
-			return vk::AttachmentStoreOp::eStore;
-		case PassStoreOperation::discard:
-			return vk::AttachmentStoreOp::eDontCare;
-		}
-		assert(false);
-		return vk::AttachmentStoreOp::eStore;
-	}
-
-
-
-
+    using namespace river::flags;
+    return vk_format_map[+df];
 }
+
+inline constexpr vk::ImageAspectFlags aspect_flags(vk::Format format)
+{
+    switch (format) {
+    case vk::Format::eD32SfloatS8Uint:
+    case vk::Format::eD24UnormS8Uint:
+    case vk::Format::eD16UnormS8Uint:
+        return vk::ImageAspectFlagBits::eDepth | vk::ImageAspectFlagBits::eStencil;
+    case vk::Format::eD16Unorm:
+    case vk::Format::eD32Sfloat:
+    case vk::Format::eX8D24UnormPack32:
+        return vk::ImageAspectFlagBits::eDepth;
+    case vk::Format::eS8Uint:
+        return vk::ImageAspectFlagBits::eStencil;
+    default:
+        return vk::ImageAspectFlagBits::eColor;
+    }
+}
+
+inline constexpr vk::Format convert_vk(wis::DataFormat df)
+{
+    return vk_format(df);
+}
+inline constexpr vk::ImageLayout convert_vk(TextureState state)
+{
+    using enum vk::ImageLayout;
+    using enum TextureState;
+    switch (state) {
+    case Undefined:
+        return eUndefined;
+    default:
+    case Common:
+        return eGeneral;
+    case Read:
+        return eReadOnlyOptimal;
+    case RenderTarget:
+        return eColorAttachmentOptimal;
+    case DepthWrite:
+        return eDepthStencilAttachmentOptimal;
+    case DepthRead:
+        return eDepthStencilReadOnlyOptimal;
+    case ShaderResource:
+        return eShaderReadOnlyOptimal;
+    case CopySrc:
+        return eTransferSrcOptimal;
+    case CopyDst:
+        return eTransferDstOptimal;
+    case VRSSource:
+        return eFragmentShadingRateAttachmentOptimalKHR;
+    case VideoDecodeRead:
+        return eVideoDecodeSrcKHR;
+    case VideoDecodeWrite:
+        return eVideoDecodeDstKHR;
+    // case VideoEncodeRead:
+    //	return eVideoEncodeSrcKHR;
+    // case VideoEncodeWrite:
+    //	return eVideoEncodeDstKHR;
+    case Present:
+        return ePresentSrcKHR;
+    }
+}
+inline constexpr vk::AccessFlags convert_vk(ResourceAccess access)
+{
+    using namespace river::flags;
+    uint32_t result{};
+    if (access == ResourceAccess::Common)
+        return vk::AccessFlags(+vk::AccessFlagBits::eMemoryRead | +vk::AccessFlagBits::eMemoryWrite);
+    if ((access & ResourceAccess::VertexBuffer) != 0u)
+        result |= VK_ACCESS_VERTEX_ATTRIBUTE_READ_BIT;
+    if ((access & ResourceAccess::ConstantBuffer) != 0u)
+        result |= VK_ACCESS_UNIFORM_READ_BIT;
+    if ((access & ResourceAccess::IndexBuffer) != 0u)
+        result |= VK_ACCESS_INDEX_READ_BIT;
+    if ((access & ResourceAccess::RenderTarget) != 0u)
+        result |= VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT;
+    if ((access & ResourceAccess::UnorderedAccess) != 0u)
+        result |= VK_ACCESS_SHADER_WRITE_BIT | VK_ACCESS_SHADER_READ_BIT;
+    if ((access & ResourceAccess::DepthWrite) != 0u)
+        result |= VK_ACCESS_DEPTH_STENCIL_ATTACHMENT_WRITE_BIT;
+    if ((access & ResourceAccess::DepthRead) != 0u)
+        result |= VK_ACCESS_DEPTH_STENCIL_ATTACHMENT_READ_BIT;
+    if ((access & ResourceAccess::ShaderResource) != 0u)
+        result |= VK_ACCESS_SHADER_READ_BIT;
+    if ((access & ResourceAccess::TransformFeedback) != 0u)
+        result |= VK_ACCESS_TRANSFORM_FEEDBACK_WRITE_BIT_EXT;
+    if ((access & ResourceAccess::IndirectCommandRead) != 0u)
+        result |= VK_ACCESS_INDIRECT_COMMAND_READ_BIT;
+    if ((access & ResourceAccess::CopySource) != 0u)
+        result |= VK_ACCESS_TRANSFER_READ_BIT;
+    if ((access & ResourceAccess::CopyDest) != 0u)
+        result |= VK_ACCESS_TRANSFER_WRITE_BIT;
+    if ((access & ResourceAccess::RayTracingRead) != 0u)
+        result |= VK_ACCESS_ACCELERATION_STRUCTURE_READ_BIT_KHR;
+    if ((access & ResourceAccess::RayTracingWrite) != 0u)
+        result |= VK_ACCESS_ACCELERATION_STRUCTURE_WRITE_BIT_KHR;
+    if ((access & ResourceAccess::VRSSource) != 0u)
+        result |= VK_ACCESS_FRAGMENT_SHADING_RATE_ATTACHMENT_READ_BIT_KHR;
+    if ((access & ResourceAccess::NoAccess) != 0u)
+        result |= VK_ACCESS_NONE;
+    return vk::AccessFlags(result);
+}
+inline constexpr vk::ImageSubresourceRange convert_vk(wis::SubresourceRange range, vk::Format format)
+{
+    return vk::ImageSubresourceRange{
+        aspect_flags(format),
+        range.base_mip,
+        range.extent_mips,
+        range.base_layer,
+        range.extent_layers
+    };
+}
+
+inline constexpr vk::AttachmentLoadOp convert(PassLoadOperation state)
+{
+    switch (state) {
+    case PassLoadOperation::load:
+        return vk::AttachmentLoadOp::eLoad;
+    case PassLoadOperation::clear:
+        return vk::AttachmentLoadOp::eClear;
+    case PassLoadOperation::discard:
+        return vk::AttachmentLoadOp::eDontCare;
+    }
+    assert(false);
+    return vk::AttachmentLoadOp::eLoad;
+}
+inline constexpr vk::PrimitiveTopology convert(wis::PrimitiveTopology topology)
+{
+    using enum vk::PrimitiveTopology;
+    switch (topology) {
+    default:
+    case wis::PrimitiveTopology::undefined:
+    case wis::PrimitiveTopology::trianglelist:
+        return eTriangleList;
+    case wis::PrimitiveTopology::pointlist:
+        return ePointList;
+    case wis::PrimitiveTopology::linelist:
+        return eLineList;
+    case wis::PrimitiveTopology::linestrip:
+        return eLineStrip;
+    case wis::PrimitiveTopology::trianglestrip:
+        return eTriangleStrip;
+    case wis::PrimitiveTopology::trianglefan:
+        return eTriangleFan;
+    case wis::PrimitiveTopology::linelist_adj:
+        return eLineListWithAdjacency;
+    case wis::PrimitiveTopology::linestrip_adj:
+        return eLineStripWithAdjacency;
+    case wis::PrimitiveTopology::trianglelist_adj:
+    case wis::PrimitiveTopology::trianglestrip_adj:
+        return eTriangleListWithAdjacency;
+    }
+}
+inline constexpr vk::AttachmentStoreOp convert(PassStoreOperation state)
+{
+    switch (state) {
+    case PassStoreOperation::store:
+        return vk::AttachmentStoreOp::eStore;
+    case PassStoreOperation::discard:
+        return vk::AttachmentStoreOp::eDontCare;
+    }
+    assert(false);
+    return vk::AttachmentStoreOp::eStore;
+}
+
+} // namespace wis

--- a/wisdom/include/wisdom/vulkan/vk_pipeline_state.h
+++ b/wisdom/include/wisdom/vulkan/vk_pipeline_state.h
@@ -6,41 +6,41 @@
 
 WIS_EXPORT namespace wis
 {
-	class VKPipelineState;
+    class VKPipelineState;
 
-	template<>
-	class Internal<VKPipelineState>
-	{
-	public:
-		Internal() = default;
-		Internal(wis::shared_handle<vk::Pipeline> pipeline): pipeline(std::move(pipeline)){};
-	public:
-		auto GetPipeline()const noexcept
-		{
-			return pipeline.get();
-		}
-	private:
-		wis::shared_handle<vk::Pipeline> pipeline;
-	};
+    template<>
+    class Internal<VKPipelineState>
+    {
+    public:
+        Internal() = default;
+        Internal(wis::shared_handle<vk::Pipeline> pipeline)
+            : pipeline(std::move(pipeline)){};
 
+        [[nodiscard]] auto GetPipeline() const noexcept
+        {
+            return pipeline.get();
+        }
 
+    private:
+        wis::shared_handle<vk::Pipeline> pipeline;
+    };
 
-	/// @brief Pipeline state object
-	class VKPipelineState : public QueryInternal<VKPipelineState>
-	{
-	public:
-		VKPipelineState() = default;
-		explicit VKPipelineState(wis::shared_handle<vk::Pipeline> pipeline)
-			:QueryInternal(std::move(pipeline))
-		{}
-		operator VKPipelineStateView()const noexcept
-		{
-			return GetPipeline();
-		}
-		operator bool()const noexcept
-		{
-			return bool(GetPipeline());
-		}
-	};
-
+    /// @brief Pipeline state object
+    class VKPipelineState : public QueryInternal<VKPipelineState>
+    {
+    public:
+        VKPipelineState() = default;
+        explicit VKPipelineState(wis::shared_handle<vk::Pipeline> pipeline)
+            : QueryInternal(std::move(pipeline))
+        {
+        }
+        operator VKPipelineStateView() const noexcept
+        {
+            return GetPipeline();
+        }
+        operator bool() const noexcept
+        {
+            return bool(GetPipeline());
+        }
+    };
 }

--- a/wisdom/include/wisdom/vulkan/vk_render_pass.h
+++ b/wisdom/include/wisdom/vulkan/vk_render_pass.h
@@ -7,49 +7,50 @@
 
 WIS_EXPORT namespace wis
 {
-	class VKRenderPass;
+    class VKRenderPass;
 
-	template<>
-	class Internal<VKRenderPass>
-	{
-	public:
-		Internal() = default;
-		Internal(wis::shared_handle<vk::RenderPass> rp, wis::shared_handle<vk::Framebuffer> frame)
-			:rp(std::move(rp)), frame(std::move(frame)) {}
-	public:
-		auto GetRenderPass()const noexcept
-		{
-			return rp.get();
-		}
-		auto GetFramebuffer()const noexcept
-		{
-			return frame.get();
-		}
-	private:
-		wis::shared_handle<vk::RenderPass> rp;
-		wis::shared_handle<vk::Framebuffer> frame;
-	};
+    template<>
+    class Internal<VKRenderPass>
+    {
+    public:
+        Internal() = default;
+        Internal(wis::shared_handle<vk::RenderPass> rp, wis::shared_handle<vk::Framebuffer> frame)
+            : rp(std::move(rp)), frame(std::move(frame)) { }
 
+        [[nodiscard]] auto GetRenderPass() const noexcept
+        {
+            return rp.get();
+        }
+        [[nodiscard]] auto GetFramebuffer() const noexcept
+        {
+            return frame.get();
+        }
 
+    private:
+        wis::shared_handle<vk::RenderPass> rp;
+        wis::shared_handle<vk::Framebuffer> frame;
+    };
 
-	// TODO: Dynamic rendering
-	class VKRenderPass : public QueryInternal<VKRenderPass>
-	{
-	public:
-		VKRenderPass() = default;
-		explicit VKRenderPass(wis::shared_handle<vk::RenderPass> rp, wis::shared_handle<vk::Framebuffer> frame, Size2D frame_size)
-			:QueryInternal(std::move(rp), std::move(frame)), framebuffer_size(frame_size)
-		{}
-	public:
-		operator VKRenderPassView()const noexcept
-		{
-			return { GetRenderPass(), GetFramebuffer(), framebuffer_size };
-		}
-		Size2D GetFramebufferSize()const noexcept
-		{
-			return framebuffer_size;
-		}
-	private:
-		Size2D framebuffer_size{ 0,0 };
-	};
+    // TODO: Dynamic rendering
+    class VKRenderPass : public QueryInternal<VKRenderPass>
+    {
+    public:
+        VKRenderPass() = default;
+        explicit VKRenderPass(wis::shared_handle<vk::RenderPass> rp, wis::shared_handle<vk::Framebuffer> frame, Size2D frame_size)
+            : QueryInternal(std::move(rp), std::move(frame)), framebuffer_size(frame_size)
+        {
+        }
+
+        operator VKRenderPassView() const noexcept
+        {
+            return { GetRenderPass(), GetFramebuffer(), framebuffer_size };
+        }
+        [[nodiscard]] Size2D GetFramebufferSize() const noexcept
+        {
+            return framebuffer_size;
+        }
+
+    private:
+        Size2D framebuffer_size{ 0, 0 };
+    };
 }

--- a/wisdom/include/wisdom/vulkan/vk_resource.h
+++ b/wisdom/include/wisdom/vulkan/vk_resource.h
@@ -18,16 +18,15 @@ WIS_EXPORT namespace wis
         Internal(wis::shared_handle<vk::Buffer> buffer, wis::shared_handle<vma::Allocation> allocation, vk::DeviceSize size)
             : buffer(std::move(buffer)), allocation(std::move(allocation)), size(size) { }
 
-    public:
-        auto GetResource() const noexcept
+        [[nodiscard]] auto GetResource() const noexcept
         {
             return buffer.get();
         }
-        auto GetAllocation() const noexcept
+        [[nodiscard]] auto GetAllocation() const noexcept
         {
             return allocation.get();
         }
-        auto GetSize() const noexcept
+        [[nodiscard]] auto GetSize() const noexcept
         {
             return size;
         }
@@ -51,13 +50,12 @@ WIS_EXPORT namespace wis
             return GetResource();
         }
 
-    public:
         bool UpdateSubresource(std::span<const std::byte> data) noexcept
         {
             auto vma = allocation.getAllocator().get();
             auto al = allocation.get();
             auto *mem = vma.mapMemory(al);
-            if (!mem)
+            if (mem == nullptr)
                 return false;
 
             auto data_size = data.size();
@@ -70,16 +68,16 @@ WIS_EXPORT namespace wis
             auto vma = allocation.getAllocator().get();
             auto al = allocation.get();
             auto *mem = vma.mapMemory(al);
-            if (!mem)
+            if (mem == nullptr)
                 return {};
-            return { reinterpret_cast<std::byte*>(mem), size };
+            return { reinterpret_cast<std::byte *>(mem), size };
         }
         void UnmapMemory() noexcept
         {
-			auto vma = allocation.getAllocator().get();
-			auto al = allocation.get();
-			vma.unmapMemory(al);
-		}
+            auto vma = allocation.getAllocator().get();
+            auto al = allocation.get();
+            vma.unmapMemory(al);
+        }
 
         [[nodiscard]] VKVertexBufferView GetVertexBufferView(uint32_t byte_stride) const noexcept
         {
@@ -97,8 +95,7 @@ WIS_EXPORT namespace wis
         Internal(wis::shared_handle<vk::Image> buffer, wis::shared_handle<vma::Allocation> allocation, vk::Format format)
             : buffer(std::move(buffer)), allocation(std::move(allocation)), format(format) { }
 
-    public:
-        auto GetResource() const noexcept
+        [[nodiscard]] auto GetResource() const noexcept
         {
             return buffer.get();
         }

--- a/wisdom/include/wisdom/vulkan/vk_root_signature.h
+++ b/wisdom/include/wisdom/vulkan/vk_root_signature.h
@@ -6,36 +6,38 @@
 
 WIS_EXPORT namespace wis
 {
-	class VKRootSignature;
+    class VKRootSignature;
 
-	template<>
-	class Internal<VKRootSignature>
-	{
-	public:
-		Internal() = default;
-		Internal(wis::shared_handle<vk::PipelineLayout> root) :root(std::move(root)) {}
-	public:
-		auto GetRootSignature()const noexcept
-		{
-			return root.get();
-		}
-	protected:
-		wis::shared_handle<vk::PipelineLayout> root;
-	};
+    template<>
+    class Internal<VKRootSignature>
+    {
+    public:
+        Internal() = default;
+        Internal(wis::shared_handle<vk::PipelineLayout> root)
+            : root(std::move(root)) { }
 
+        [[nodiscard]] auto GetRootSignature() const noexcept
+        {
+            return root.get();
+        }
 
-	/// @brief Root signature
-	class VKRootSignature : public QueryInternal<VKRootSignature>
-	{
-	public:
-		VKRootSignature() = default;
-		explicit VKRootSignature(wis::shared_handle<vk::PipelineLayout> root)
-			:QueryInternal(std::move(root))
-		{}
-	public:
-		operator VKRootSignatureView()const noexcept
-		{
-			return GetRootSignature();
-		}
-	};
+    protected:
+        wis::shared_handle<vk::PipelineLayout> root;
+    };
+
+    /// @brief Root signature
+    class VKRootSignature : public QueryInternal<VKRootSignature>
+    {
+    public:
+        VKRootSignature() = default;
+        explicit VKRootSignature(wis::shared_handle<vk::PipelineLayout> root)
+            : QueryInternal(std::move(root))
+        {
+        }
+
+        operator VKRootSignatureView() const noexcept
+        {
+            return GetRootSignature();
+        }
+    };
 }

--- a/wisdom/include/wisdom/vulkan/vk_rtv.h
+++ b/wisdom/include/wisdom/vulkan/vk_rtv.h
@@ -6,36 +6,38 @@
 
 WIS_EXPORT namespace wis
 {
-	class VKRenderTargetView;
+    class VKRenderTargetView;
 
-	template<>
-	class Internal<VKRenderTargetView>
-	{
-	public:
-		Internal() = default;
-		Internal(wis::shared_handle<vk::ImageView> view)
-			:view(std::move(view))
-		{}
-	public:
-		auto GetViewHandle()const noexcept
-		{
-			return view;
-		}
-		auto GetImageView()const noexcept
-		{
-			return view.get();
-		}
-	protected:
-		wis::shared_handle<vk::ImageView> view;
-	};
+    template<>
+    class Internal<VKRenderTargetView>
+    {
+    public:
+        Internal() = default;
+        Internal(wis::shared_handle<vk::ImageView> view)
+            : view(std::move(view))
+        {
+        }
 
+        [[nodiscard]] auto GetViewHandle() const noexcept
+        {
+            return view;
+        }
+        [[nodiscard]] auto GetImageView() const noexcept
+        {
+            return view.get();
+        }
 
-	class VKRenderTargetView : public QueryInternal<VKRenderTargetView>
-	{
-	public:
-		VKRenderTargetView() = default;
-		explicit VKRenderTargetView(wis::shared_handle<vk::ImageView> view)
-			:QueryInternal(std::move(view))
-		{}
-	};
+    protected:
+        wis::shared_handle<vk::ImageView> view;
+    };
+
+    class VKRenderTargetView : public QueryInternal<VKRenderTargetView>
+    {
+    public:
+        VKRenderTargetView() = default;
+        explicit VKRenderTargetView(wis::shared_handle<vk::ImageView> view)
+            : QueryInternal(std::move(view))
+        {
+        }
+    };
 }

--- a/wisdom/include/wisdom/vulkan/vk_shader.h
+++ b/wisdom/include/wisdom/vulkan/vk_shader.h
@@ -4,50 +4,52 @@
 #include <wisdom/api/api_shader.h>
 #include <wisdom/vulkan/vk_shared_handle.h>
 #endif
-	
+
 WIS_EXPORT namespace wis
 {
-	class VKShader;
+    class VKShader;
 
-	template<>
-	class Internal<VKShader>
-	{
-	public:
-		Internal() = default;
-		Internal(wis::shared_handle<vk::ShaderModule> module):module(std::move(module)) {};
-	public:
-		auto GetShaderModule()const noexcept
-		{
-			return module.get();
-		}
-	protected:
-		wis::shared_handle<vk::ShaderModule> module;
-	};
+    template<>
+    class Internal<VKShader>
+    {
+    public:
+        Internal() = default;
+        Internal(wis::shared_handle<vk::ShaderModule> module)
+            : module(std::move(module)){};
 
-	/// @brief Shader object
-	class VKShader : public QueryInternal<VKShader>
-	{
-	public:
-		using DataType = uint32_t;
-		static constexpr inline ShaderLang language = ShaderLang::spirv;
-	public:
-		VKShader() = default;
-		explicit VKShader(wis::shared_handle<vk::ShaderModule> module, ShaderType type)
-			:QueryInternal(std::move(module)), type(type)
-		{}
-	public:
-		operator bool()const noexcept
-		{
-			return type != ShaderType::unknown && module;
-		}
-		/// @brief Get shader type e.g. vertex, fragment
-		/// @return Type of shader
-		[[nodiscard]]
-		auto GetType()const noexcept
-		{
-			return type;
-		}
-	public:
-		ShaderType type = ShaderType::unknown;
-	};
+        [[nodiscard]] auto GetShaderModule() const noexcept
+        {
+            return module.get();
+        }
+
+    protected:
+        wis::shared_handle<vk::ShaderModule> module;
+    };
+
+    /// @brief Shader object
+    class VKShader : public QueryInternal<VKShader>
+    {
+    public:
+        using DataType = uint32_t;
+        static constexpr inline ShaderLang language = ShaderLang::spirv;
+
+        VKShader() = default;
+        explicit VKShader(wis::shared_handle<vk::ShaderModule> module, ShaderType type)
+            : QueryInternal(std::move(module)), type(type)
+        {
+        }
+
+        operator bool() const noexcept
+        {
+            return type != ShaderType::unknown && module;
+        }
+        /// @brief Get shader type e.g. vertex, fragment
+        /// @return Type of shader
+        [[nodiscard]] auto GetType() const noexcept
+        {
+            return type;
+        }
+
+        ShaderType type = ShaderType::unknown;
+    };
 }

--- a/wisdom/include/wisdom/vulkan/vk_shared_handle.h
+++ b/wisdom/include/wisdom/vulkan/vk_shared_handle.h
@@ -5,12 +5,12 @@
 
 WIS_EXPORT namespace wis
 {
-	using vk::SharedHandle;
+    using vk::SharedHandle;
 
     template<typename HandleType>
     class shared_handle : public vk::SharedHandle<HandleType>
     {
     public:
-		using vk::SharedHandle<HandleType>::SharedHandle;
+        using vk::SharedHandle<HandleType>::SharedHandle;
     };
 }

--- a/wisdom/include/wisdom/vulkan/vk_state_builder.h
+++ b/wisdom/include/wisdom/vulkan/vk_state_builder.h
@@ -7,66 +7,73 @@
 
 WIS_EXPORT namespace wis
 {
-	class VKGraphicsPipelineDesc
-	{
-		friend class VKDevice;
-	public:
-		VKGraphicsPipelineDesc(VKRootSignature sig)noexcept
-			:sig(std::move(sig))
-		{}
-	public:
-		VKGraphicsPipelineDesc& SetVS(VKShader vs)noexcept
-		{
-			this->vs = std::move(vs); return *this;
-		}
-		VKGraphicsPipelineDesc& SetPS(VKShader ps)noexcept
-		{
-			this->ps = std::move(ps); return *this;
-		}
-		VKGraphicsPipelineDesc& SetGS(VKShader gs)noexcept
-		{
-			this->gs = std::move(gs); return *this;
-		}
-		VKGraphicsPipelineDesc& SetHS(VKShader hs)noexcept
-		{
-			this->hs = std::move(hs); return *this;
-		}
-		VKGraphicsPipelineDesc& SetDS(VKShader ds)noexcept
-		{
-			this->ds = std::move(ds); return *this;
-		}
-		VKGraphicsPipelineDesc& SetShader(VKShader shader)noexcept
-		{
-			using enum ShaderType;
-			switch (shader.GetType())
-			{
-			case vertex:
-				return SetVS(std::move(shader));
-			case pixel:
-				return SetPS(std::move(shader));
-			case geometry:
-				return SetGS(std::move(shader));
-			case hull:
-				return SetHS(std::move(shader));
-			case domain:
-				return SetDS(std::move(shader));
-			default:
-				break;
-			}
-			return *this;
-		}
-		VKGraphicsPipelineDesc& SetRenderPass(VKRenderPass pass)noexcept
-		{
-			this->pass = std::move(pass);
-			return *this;
-		}
-	private:
-		VKRootSignature sig;
-		VKShader vs;
-		VKShader ps;
-		VKShader gs;
-		VKShader hs;
-		VKShader ds;
-		VKRenderPass pass;
-	};
+    class VKGraphicsPipelineDesc
+    {
+        friend class VKDevice;
+
+    public:
+        VKGraphicsPipelineDesc(VKRootSignature sig) noexcept
+            : sig(std::move(sig))
+        {
+        }
+
+        VKGraphicsPipelineDesc &SetVS(VKShader vs) noexcept
+        {
+            this->vs = std::move(vs);
+            return *this;
+        }
+        VKGraphicsPipelineDesc &SetPS(VKShader ps) noexcept
+        {
+            this->ps = std::move(ps);
+            return *this;
+        }
+        VKGraphicsPipelineDesc &SetGS(VKShader gs) noexcept
+        {
+            this->gs = std::move(gs);
+            return *this;
+        }
+        VKGraphicsPipelineDesc &SetHS(VKShader hs) noexcept
+        {
+            this->hs = std::move(hs);
+            return *this;
+        }
+        VKGraphicsPipelineDesc &SetDS(VKShader ds) noexcept
+        {
+            this->ds = std::move(ds);
+            return *this;
+        }
+        VKGraphicsPipelineDesc &SetShader(VKShader shader) noexcept
+        {
+            using enum ShaderType;
+            switch (shader.GetType()) {
+            case vertex:
+                return SetVS(std::move(shader));
+            case pixel:
+                return SetPS(std::move(shader));
+            case geometry:
+                return SetGS(std::move(shader));
+            case hull:
+                return SetHS(std::move(shader));
+            case domain:
+                return SetDS(std::move(shader));
+            default:
+                break;
+            }
+            return *this;
+        }
+        VKGraphicsPipelineDesc &SetRenderPass(VKRenderPass pass) noexcept
+        {
+            this->pass = std::move(pass);
+            return *this;
+        }
+
+    private:
+        VKRootSignature sig;
+        VKShader vs;
+        VKShader ps;
+        VKShader gs;
+        VKShader hs;
+        VKShader ds;
+        VKRenderPass pass;
+    };
 }

--- a/wisdom/include/wisdom/vulkan/vk_swapchain.h
+++ b/wisdom/include/wisdom/vulkan/vk_swapchain.h
@@ -30,12 +30,11 @@ WIS_EXPORT namespace wis
             present_semaphore = device.createSemaphoreUnique({});
         }
 
-    public:
-        vk::SwapchainKHR GetSwapchain() const noexcept
+        [[nodiscard]] vk::SwapchainKHR GetSwapchain() const noexcept
         {
             return swap.get();
         }
-        vk::SurfaceKHR GetSurface() const noexcept
+        [[nodiscard]] vk::SurfaceKHR GetSurface() const noexcept
         {
             return swap.getSurface().get();
         }
@@ -67,7 +66,6 @@ WIS_EXPORT namespace wis
         VKSwapChain &operator=(VKSwapChain &&) noexcept = default;
         ~VKSwapChain() { ReleaseSemaphore(); }
 
-    public:
         /// @brief Get the current image index in the swapchain
         /// @return Index of the current image
         [[nodiscard]] uint32_t GetNextIndex() const noexcept
@@ -119,7 +117,7 @@ WIS_EXPORT namespace wis
                 vk::SharingMode::eExclusive, 0u, nullptr,
                 vk::SurfaceTransformFlagBitsKHR::eIdentity,
                 vk::CompositeAlphaFlagBitsKHR::eOpaque,
-                present_mode, true, swap.get()
+                present_mode, true, swap.get() // NOLINT
             };
             swap = wis::shared_handle<vk::SwapchainKHR>{
                 device.createSwapchainKHR(desc),
@@ -156,7 +154,6 @@ WIS_EXPORT namespace wis
         WIS_INLINE bool AquireNextIndex() noexcept;
         WIS_INLINE void ReleaseSemaphore() noexcept;
 
-    private:
         VKCommandQueue present_queue;
         VKCommandList initialization; //< Initialization command list
         std::vector<VKTexture> back_buffers; //< Render targets

--- a/wisdom/include/wisdom/vulkan/vk_xshared_handle.h
+++ b/wisdom/include/wisdom/vulkan/vk_xshared_handle.h
@@ -76,7 +76,6 @@ public:
     ReferenceCounter(const ReferenceCounter &) = delete;
     ReferenceCounter &operator=(const ReferenceCounter &) = delete;
 
-public:
     size_t addRef() VULKAN_HPP_NOEXCEPT
     {
         return m_ref_cnt.fetch_add(1, std::memory_order_relaxed);
@@ -87,7 +86,6 @@ public:
         return m_ref_cnt.fetch_sub(1, std::memory_order_acq_rel);
     }
 
-public:
     std::atomic_size_t m_ref_cnt{ 1 };
     HeaderType m_header{};
 };
@@ -100,7 +98,6 @@ class SharedHandleBase
 public:
     using ParentType = parent_of_t<HandleType>;
 
-public:
     SharedHandleBase() = default;
 
     template<typename... Args>
@@ -146,8 +143,7 @@ public:
         }
     }
 
-public:
-    HandleType get() const VULKAN_HPP_NOEXCEPT
+    [[nodiscard]] HandleType get() const VULKAN_HPP_NOEXCEPT
     {
         return m_handle;
     }
@@ -197,7 +193,7 @@ protected:
         control.deleter.destroy(control.parent.get(), handle);
     }
 
-    const HeaderType &getHeader() const VULKAN_HPP_NOEXCEPT
+    [[nodiscard]] const HeaderType &getHeader() const VULKAN_HPP_NOEXCEPT
     {
         return m_control->m_header;
     }
@@ -273,7 +269,6 @@ public:
     {
     }
 
-public:
     template<typename T = HandleType>
     typename std::enable_if<has_parent<T>, void>::type destroy(ParentType parent, HandleType handle) const VULKAN_HPP_NOEXCEPT
     {
@@ -314,7 +309,6 @@ public:
     {
     }
 
-public:
     void destroy(ParentType parent, HandleType handle) const VULKAN_HPP_NOEXCEPT
     {
         VULKAN_HPP_ASSERT(m_destroy && m_dispatch);
@@ -339,13 +333,12 @@ public:
     using destroy_pfn_t = void (ParentType::*)(HandleType, const Dispatcher &) const;
 
     template<class Dispatcher = VULKAN_HPP_DEFAULT_DISPATCHER_TYPE>
-    ObjectReleaseShared(Optional<const AllocationCallbacks> allocationCallbacks VULKAN_HPP_DEFAULT_ARGUMENT_NULLPTR_ASSIGNMENT,
+    ObjectReleaseShared(Optional<const AllocationCallbacks> /*allocationCallbacks*/ VULKAN_HPP_DEFAULT_ARGUMENT_NULLPTR_ASSIGNMENT,
                         const Dispatcher &dispatch VULKAN_HPP_DEFAULT_DISPATCHER_ASSIGNMENT)
         : m_destroy(reinterpret_cast<decltype(m_destroy)>(static_cast<destroy_pfn_t<Dispatcher>>(&ParentType::release))), m_dispatch(&dispatch)
     {
     }
 
-public:
     void destroy(ParentType parent, HandleType handle) const VULKAN_HPP_NOEXCEPT
     {
         VULKAN_HPP_ASSERT(m_destroy && m_dispatch);
@@ -381,7 +374,6 @@ public:
     {
     }
 
-public:
     void destroy(ParentType parent, HandleType handle) const VULKAN_HPP_NOEXCEPT
     {
         VULKAN_HPP_ASSERT(m_destroy && m_dispatch);
@@ -820,7 +812,7 @@ struct ImageHeader : SharedHeader<parent_of_t<VULKAN_HPP_NAMESPACE::Image>, type
             typename VULKAN_HPP_NAMESPACE::SharedHandleTraits<VULKAN_HPP_NAMESPACE::Image>::deleter deleter = typename VULKAN_HPP_NAMESPACE::SharedHandleTraits<VULKAN_HPP_NAMESPACE::Image>::deleter(),
             SwapchainOwns swapchainOwned = SwapchainOwns::no) VULKAN_HPP_NOEXCEPT
         : SharedHeader<parent_of_t<VULKAN_HPP_NAMESPACE::Image>, typename VULKAN_HPP_NAMESPACE::SharedHandleTraits<VULKAN_HPP_NAMESPACE::Image>::deleter>(std::move(parent),
-                                                                                                                                                          std::move(deleter)),
+                                                                                                                                                          deleter),
           swapchainOwned(swapchainOwned)
     {
     }
@@ -838,14 +830,13 @@ class SharedHandle<VULKAN_HPP_NAMESPACE::Image> : public SharedHandleBase<VULKAN
 public:
     using element_type = VULKAN_HPP_NAMESPACE::Image;
 
-public:
     SharedHandle() = default;
 
     explicit SharedHandle(VULKAN_HPP_NAMESPACE::Image handle,
                           SharedHandle<typename BaseType::ParentType> parent,
                           SwapchainOwns swapchain_owned = SwapchainOwns::no,
                           DeleterType deleter = DeleterType()) VULKAN_HPP_NOEXCEPT
-        : BaseType(handle, std::move(parent), std::move(deleter), swapchain_owned)
+        : BaseType(handle, std::move(parent), deleter, swapchain_owned)
     {
     }
 
@@ -865,7 +856,7 @@ struct SwapchainHeader {
                             typename VULKAN_HPP_NAMESPACE::SharedHandleTraits<VULKAN_HPP_NAMESPACE::SwapchainKHR>::deleter()) VULKAN_HPP_NOEXCEPT
         : surface(std::move(surface)),
           parent(std::move(parent)),
-          deleter(std::move(deleter))
+          deleter(deleter)
     {
     }
 
@@ -884,19 +875,17 @@ class SharedHandle<VULKAN_HPP_NAMESPACE::SwapchainKHR> : public SharedHandleBase
 public:
     using element_type = VULKAN_HPP_NAMESPACE::SwapchainKHR;
 
-public:
     SharedHandle() = default;
 
     explicit SharedHandle(VULKAN_HPP_NAMESPACE::SwapchainKHR handle,
                           SharedHandle<typename BaseType::ParentType> parent,
                           SharedHandle<VULKAN_HPP_NAMESPACE::SurfaceKHR> surface,
                           DeleterType deleter = DeleterType()) VULKAN_HPP_NOEXCEPT
-        : BaseType(handle, std::move(surface), std::move(parent), std::move(deleter))
+        : BaseType(handle, std::move(surface), std::move(parent), deleter)
     {
     }
 
-public:
-    const SharedHandle<VULKAN_HPP_NAMESPACE::SurfaceKHR> &getSurface() const VULKAN_HPP_NOEXCEPT
+    [[nodiscard]] const SharedHandle<VULKAN_HPP_NAMESPACE::SurfaceKHR> &getSurface() const VULKAN_HPP_NOEXCEPT
     {
         return getHeader().surface;
     }

--- a/wisdom/include/wisdom/wisdom.h
+++ b/wisdom/include/wisdom/wisdom.h
@@ -4,24 +4,22 @@
 // Override with WISDOM_FORCE_VULKAN
 
 #ifdef WISDOM_UWP
-static_assert(WISDOM_UWP&& _WIN32, "Platform error");
+static_assert(WISDOM_UWP && _WIN32, "Platform error");
 #endif // WISDOM_UWP
 
 #ifdef WISDOM_WINDOWS
-static_assert(WISDOM_WINDOWS&& _WIN32, "Platform error");
+static_assert(WISDOM_WINDOWS && _WIN32, "Platform error");
 #endif // WISDOM_WINDOWS
 
 #ifdef WISDOM_LINUX
-static_assert(WISDOM_LINUX&& __linux__, "Platform error");
+static_assert(WISDOM_LINUX && __linux__, "Platform error");
 #endif // WISDOM_LINUX
 
-#if defined(WISDOM_VULKAN_FOUND) && defined(WISDOM_FORCE_VULKAN) 
+#if defined(WISDOM_VULKAN_FOUND) && defined(WISDOM_FORCE_VULKAN)
 #define FORCEVK_SWITCH 1
 #else
 #define FORCEVK_SWITCH 0
 #endif // WISDOM_VULKAN_FOUND
-
-
 
 #if WISDOMDX12 && !FORCEVK_SWITCH
 
@@ -32,31 +30,31 @@ static_assert(WISDOM_LINUX&& __linux__, "Platform error");
 #include <wisdom/dx12/dx12_device.h>
 #endif // WISDOMDX12 && !FORCEVK_SWITCH
 
-//dx12
+// dx12
 WIS_EXPORT namespace wis
 {
-	using Factory = DX12Factory;
-	using Adapter = DX12Adapter;
-	using Device = DX12Device;
-	using CommandQueue = DX12CommandQueue;
-	using SwapChain = DX12SwapChain;
-	using CommandList = DX12CommandList;
-	using Fence = DX12Fence;
-	using Buffer = DX12Buffer;
-	using RenderTargetView = DX12RenderTargetView;
-	using Shader = DX12Shader;
-	using RootSignature = DX12RootSignature;
-	using PipelineState = DX12PipelineState;
-	using ResourceAllocator = DX12ResourceAllocator;
-	using GraphicsPipelineDesc = DX12GraphicsPipelineDesc;
-	using VertexBufferView = DX12VertexBufferView;
-	using RenderPass = DX12RenderPass;
-	using DescriptorHeap = DX12DescriptorHeap;
-	using DescriptorSetLayout = DX12DescriptorSetLayout;
-	using DescriptorSet = DX12DescriptorSet;
+    using Factory = DX12Factory;
+    using Adapter = DX12Adapter;
+    using Device = DX12Device;
+    using CommandQueue = DX12CommandQueue;
+    using SwapChain = DX12SwapChain;
+    using CommandList = DX12CommandList;
+    using Fence = DX12Fence;
+    using Buffer = DX12Buffer;
+    using RenderTargetView = DX12RenderTargetView;
+    using Shader = DX12Shader;
+    using RootSignature = DX12RootSignature;
+    using PipelineState = DX12PipelineState;
+    using ResourceAllocator = DX12ResourceAllocator;
+    using GraphicsPipelineDesc = DX12GraphicsPipelineDesc;
+    using VertexBufferView = DX12VertexBufferView;
+    using RenderPass = DX12RenderPass;
+    using DescriptorHeap = DX12DescriptorHeap;
+    using DescriptorSetLayout = DX12DescriptorSetLayout;
+    using DescriptorSet = DX12DescriptorSet;
 }
-#elif WISDOMMTL && !FORCEVK_SWITCH //MAC
-//metal
+#elif WISDOMMTL && !FORCEVK_SWITCH // MAC
+// metal
 WIS_EXPORT namespace wis
 {
 }
@@ -67,28 +65,28 @@ WIS_EXPORT namespace wis
 #include <wisdom/vulkan/vk_state_builder.h>
 #endif // !WISDOM_MODULES
 
-//vulkan
+// vulkan
 WIS_EXPORT namespace wis
 {
-	using Factory = VKFactory;
-	using Adapter = VKAdapter;
-	using Device = VKDevice;
-	using CommandQueue = VKCommandQueue;
-	using SwapChain = VKSwapChain;
-	using CommandList = VKCommandList;
-	using Fence = VKFence;
-	using Buffer = VKBuffer;
-	using RenderTargetView = VKRenderTargetView;
-	using Shader = VKShader;
-	using RootSignature = VKRootSignature;
-	using PipelineState = VKPipelineState;
-	using ResourceAllocator = VKResourceAllocator;
-	using GraphicsPipelineDesc = VKGraphicsPipelineDesc;
-	using VertexBufferView = VKVertexBufferView;
-	using RenderPass = VKRenderPass;
-	using DescriptorHeap = VKDescriptorHeap;
-	using DescriptorSetLayout = VKDescriptorSetLayout;
-	using DescriptorSet = VKDescriptorSet;
+    using Factory = VKFactory;
+    using Adapter = VKAdapter;
+    using Device = VKDevice;
+    using CommandQueue = VKCommandQueue;
+    using SwapChain = VKSwapChain;
+    using CommandList = VKCommandList;
+    using Fence = VKFence;
+    using Buffer = VKBuffer;
+    using RenderTargetView = VKRenderTargetView;
+    using Shader = VKShader;
+    using RootSignature = VKRootSignature;
+    using PipelineState = VKPipelineState;
+    using ResourceAllocator = VKResourceAllocator;
+    using GraphicsPipelineDesc = VKGraphicsPipelineDesc;
+    using VertexBufferView = VKVertexBufferView;
+    using RenderPass = VKRenderPass;
+    using DescriptorHeap = VKDescriptorHeap;
+    using DescriptorSetLayout = VKDescriptorSetLayout;
+    using DescriptorSet = VKDescriptorSet;
 }
 #else
 #error "No API selected"

--- a/wisdom/modules/api.ixx
+++ b/wisdom/modules/api.ixx
@@ -14,7 +14,7 @@ module;
 #include <xcb/xproto.h>
 #endif // WISDOM_LINUX
 
-#pragma warning(disable: 5244) //includes are interop, and not a mistake
+#pragma warning(disable : 5244) // includes are interop, and not a mistake
 #define WISDOM_MODULES
 export module wisdom.api;
 
@@ -36,10 +36,9 @@ export module wisdom.api;
 #include <wisdom/api/api_internal.h>
 #include <wisdom/api/api_swapchain.h>
 
-export namespace wis
-{
-	using wis::generator;
-	using wis::source_location;
-	using wis::format;
-	using wis::format_to;
-}
+export namespace wis {
+using wis::format;
+using wis::format_to;
+using wis::generator;
+using wis::source_location;
+} // namespace wis

--- a/wisdom/modules/dx12.ixx
+++ b/wisdom/modules/dx12.ixx
@@ -11,7 +11,7 @@ module;
 #include <array>
 #include <winrt/base.h>
 
-#pragma warning(disable: 5244) //includes are interop, and not a mistake
+#pragma warning(disable : 5244) // includes are interop, and not a mistake
 #define WISDOM_MODULES
 export module wisdom.dx12;
 
@@ -36,7 +36,6 @@ import wisdom.api;
 #include <wisdom/dx12/dx12_state_builder.h>
 #include <wisdom/dx12/dx12_fence.h>
 #include <wisdom/dx12/dx12_swapchain.h>
-
 
 #include <wisdom/dx12/dx12_command_list.h>
 #include <wisdom/dx12/dx12_command_queue.h>

--- a/wisdom/modules/vulkan.ixx
+++ b/wisdom/modules/vulkan.ixx
@@ -12,7 +12,7 @@ module;
 #include <vulkan/vulkan.hpp>
 
 #define WISDOM_MODULES
-#pragma warning(disable: 5244) //includes are interop, and not a mistake
+#pragma warning(disable : 5244) // includes are interop, and not a mistake
 export module wisdom.vk;
 
 import wisdom.api;
@@ -23,7 +23,6 @@ import wisdom.api;
 #include <wisdom/vulkan/vk_shared_handle.h>
 #include <wisdom/vulkan/vk_allocator_handles.h>
 #include <wisdom/vulkan/vk_views.h>
-
 
 #include <wisdom/vulkan/vk_adapter.h>
 

--- a/wisdom/modules/wisdom.ixx
+++ b/wisdom/modules/wisdom.ixx
@@ -1,5 +1,5 @@
 module;
-#pragma warning(disable: 5244) //includes are interop, and not a mistake
+#pragma warning(disable : 5244) // includes are interop, and not a mistake
 #define WISDOM_MODULES
 export module wisdom;
 

--- a/wisdom/src/wisdom/dx12.cpp
+++ b/wisdom/src/wisdom/dx12.cpp
@@ -4,7 +4,6 @@
 #include <wisdom/dx12/dx12_factory.h>
 #include <wisdom/dx12/dx12_allocator.h>
 
-
 #include <wisdom/dx12/impl/dx12_checks.inl>
 #include <wisdom/dx12/impl/dx12_info.inl>
 #include <wisdom/dx12/impl/dx12_adapter.inl>

--- a/wisdom/src/wisdom/vulkan.cpp
+++ b/wisdom/src/wisdom/vulkan.cpp
@@ -1,4 +1,4 @@
 #define WISDOM_HEADER_ONLY // Hack to compile the header only
 #include <wisdom/vulkan/vk_adapter.h>
-#include <wisdom/vulkan/vk_allocator.h> 
+#include <wisdom/vulkan/vk_allocator.h>
 #include <wisdom/vulkan/vk_device.h>


### PR DESCRIPTION
Formatted everything and obeyed most of clang-tidy's recommndations. This involved a lot of remove redundant access specifiers in classes/structs and the insertion of many new [[nodiscard]]s.