### PR TITLE
Fix enum issue

### DIFF
--- a/bindings/wisdom.h
+++ b/bindings/wisdom.h
@@ -6,7 +6,7 @@
 
 /** \mainpage Wisdom API Documentation
 
-<b>Version 0.3.12</b>
+<b>Version 0.3.14</b>
 
 Copyright (c) 2024 Ilya Doroshenko. All rights reserved.
 License: MIT
@@ -818,7 +818,7 @@ enum WisBlendFactor {
     BlendFactorDestColor = 9, ///< Use the destination color for blending.
     BlendFactorInvDestColor = 10, ///< Use the inverse destination color for blending.
     BlendFactorSrcAlphaSat = 11, ///< Use the source alpha saturated for blending.
-    BlendFactorBlendFactor = 14, ///< Use a constant blend factor for blending.
+    BlendFactorConstantColor = 14, ///< Use a constant blend factor for blending.
     BlendFactorInvBlendFactor = 15, ///< Use the inverse constant blend factor for blending.
     BlendFactorSrc1Color = 16, ///< Use the source color for blending. Dual source blending mode.
     BlendFactorInvSrc1Color = 17, ///< Use the inverse source color for blending. Dual source blending mode.

--- a/wisdom/include/wisdom/generated/api/api.h
+++ b/wisdom/include/wisdom/generated/api/api.h
@@ -5,7 +5,7 @@
 
 /** \mainpage Wisdom API Documentation
 
-<b>Version 0.3.12</b>
+<b>Version 0.3.14</b>
 
 Copyright (c) 2024 Ilya Doroshenko. All rights reserved.
 License: MIT
@@ -850,7 +850,7 @@ enum class BlendFactor : uint32_t {
     DestColor = 9, ///< Use the destination color for blending.
     InvDestColor = 10, ///< Use the inverse destination color for blending.
     SrcAlphaSat = 11, ///< Use the source alpha saturated for blending.
-    BlendFactor = 14, ///< Use a constant blend factor for blending.
+    ConstantColor = 14, ///< Use a constant blend factor for blending.
     InvBlendFactor = 15, ///< Use the inverse constant blend factor for blending.
     Src1Color = 16, ///< Use the source color for blending. Dual source blending mode.
     InvSrc1Color = 17, ///< Use the inverse source color for blending. Dual source blending mode.

--- a/wisdom/include/wisdom/generated/vulkan/vk_structs.hpp
+++ b/wisdom/include/wisdom/generated/vulkan/vk_structs.hpp
@@ -396,7 +396,7 @@ inline constexpr VkBlendFactor convert_vk(BlendFactor value) noexcept
         return VK_BLEND_FACTOR_ONE_MINUS_DST_COLOR;
     case BlendFactor::SrcAlphaSat:
         return VK_BLEND_FACTOR_SRC_ALPHA_SATURATE;
-    case BlendFactor::BlendFactor:
+    case BlendFactor::ConstantColor:
         return VK_BLEND_FACTOR_CONSTANT_COLOR;
     case BlendFactor::InvBlendFactor:
         return VK_BLEND_FACTOR_ONE_MINUS_CONSTANT_COLOR;

--- a/xml/enums.xml
+++ b/xml/enums.xml
@@ -721,7 +721,7 @@ Triangle culling depends on {WindingOrder::} option.">
       <value name="SrcAlphaSat" value="11" doc="Use the source alpha saturated for blending.">
         <impl name="vk" value="VK_BLEND_FACTOR_SRC_ALPHA_SATURATE"/>
       </value>
-      <value name="BlendFactor" value="14" doc="Use a constant blend factor for blending.">
+      <value name="ConstantColor" value="14" doc="Use a constant blend factor for blending.">
         <impl name="vk" value="VK_BLEND_FACTOR_CONSTANT_COLOR"/>
       </value>
       <value name="InvBlendFactor" value="15" doc="Use the inverse constant blend factor for blending.">


### PR DESCRIPTION
An enum was called the same as its container class. Static analysis caught this as illegal.

Regenerated the APIs from XML.