### PR TITLE
Implement move semantics and enhance resource management

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,7 +20,7 @@
 
 cmake_minimum_required(VERSION 3.22)
 
-set(WISDOM_VERSION "0.6.11")
+set(WISDOM_VERSION "0.6.12")
 project("Wisdom" VERSION ${WISDOM_VERSION})
 
 set(CMAKE_DEBUG_POSTFIX d)

--- a/bindings/wisdom.h
+++ b/bindings/wisdom.h
@@ -4,7 +4,7 @@
 #include <stdint.h>
 #include <stdbool.h>
 
-/** Wisdom API Version 0.6.11
+/** Wisdom API Version 0.6.12
 
 Copyright (c) 2024 Ilya Doroshenko. All rights reserved.
 License: MIT
@@ -1596,7 +1596,7 @@ typedef uint32_t WisASInstanceFlags;
 
 /**
  * @brief Main source of communication of operation success.
- * To check for success compare WisResult::status with StatusOk.
+ * To check for success WisResult::status *must* be compared with StatusOk.
  * If there is any error there is  string which is compile-time.
  * It communicates the source of problems even in Release mode.
  * The string contains function name and error message.

--- a/examples/custom/cross_device/work_node.h
+++ b/examples/custom/cross_device/work_node.h
@@ -91,7 +91,7 @@ public:
         return vkGetMemoryHostPointerPropertiesEXT;
     }
 
-    ExternalBuffer CreateExternalBuffer(wis::Result& result, wis::ResourceAllocator allocator, void* mapping, uint64_t size) const noexcept
+    ExternalBuffer CreateExternalBuffer(wis::Result& result, wis::ResourceAllocator& allocator, void* mapping, uint64_t size) const noexcept
     {
         ExternalBuffer buffer;
 

--- a/examples/custom/multimon/transfer_node.h
+++ b/examples/custom/multimon/transfer_node.h
@@ -95,7 +95,7 @@ public:
         return vkGetMemoryHostPointerPropertiesEXT;
     }
 
-    ExternalBuffer CreateExternalBuffer(wis::Result& result, wis::ResourceAllocator allocator, void* mapping, uint64_t size) const noexcept
+    ExternalBuffer CreateExternalBuffer(wis::Result& result, wis::ResourceAllocator& allocator, void* mapping, uint64_t size) const noexcept
     {
         ExternalBuffer buffer;
 

--- a/generator/generator.cpp
+++ b/generator/generator.cpp
@@ -2799,6 +2799,15 @@ std::string Generator::MakeCPPHandle(const WisHandle& s, std::string_view impl)
     std::string head = wis::format("{}\n WISDOM_EXPORT\nclass {}{} : public wis::Impl{}{}", doc, impl, s.name, impl, s.name);
     std::string ctor = wis::format("public:\n using wis::Impl{}{}::Impl{}{};", impl, s.name, impl, s.name);
 
+    // Only adapter has a copy constructor
+    if (s.name != "Adapter") {
+        // Explicitly prohibit copy but allow move
+        ctor += wis::format("\n{}{}(const {}{}&) = delete;\n", impl, s.name, impl, s.name);
+        ctor += wis::format("{}{}({}{}&&) noexcept = default;\n", impl, s.name, impl, s.name);
+        ctor += wis::format("{}{}& operator=(const {}{}&) = delete;\n", impl, s.name, impl, s.name);
+        ctor += wis::format("{}{}& operator=({}{}&&) noexcept = default;\n", impl, s.name, impl, s.name);
+    }
+
     std::string funcs = "public:\n";
     for (auto& f : s.functions) {
         auto& func = function_map[std::string(f)];

--- a/tests/basic/CMakeLists.txt
+++ b/tests/basic/CMakeLists.txt
@@ -1,10 +1,10 @@
 project("test-basic")
 
-set(TEST_SOURCES "relaxed_destruction_order.cpp" "extension_tests.cpp"
+set(TEST_SOURCES "relaxed_destruction_order.cpp" "extension_tests.cpp" 
                  "copy_tests.cpp")
 
 if(WISDOM_DX12)
-  add_executable(${PROJECT_NAME}-dx12 ${TEST_SOURCES})
+  add_executable(${PROJECT_NAME}-dx12 ${TEST_SOURCES} "fence_move_dx12.cpp")
   wis_install_deps(${PROJECT_NAME}-dx12)
   target_link_libraries(
     ${PROJECT_NAME}-dx12

--- a/tests/basic/fence_move_dx12.cpp
+++ b/tests/basic/fence_move_dx12.cpp
@@ -65,7 +65,9 @@ TEST_CASE("move_fence_dx12")
     auto fence2 = std::move(fence);
     REQUIRE(fence2);
 
+#if defined(WISDOM_DX12) && !defined(WISDOM_FORCE_VULKAN)
     auto& internal = fence.GetInternal();
     REQUIRE(internal.fence.get() == nullptr);
     REQUIRE(internal.fence_event.get() == 0);
+#endif
 }

--- a/tests/basic/fence_move_dx12.cpp
+++ b/tests/basic/fence_move_dx12.cpp
@@ -1,0 +1,71 @@
+#include <catch2/catch_test_macros.hpp>
+#include <wisdom/wisdom_platform.hpp>
+#include <wisdom/wisdom.hpp>
+#include <wisdom/wisdom_debug.hpp>
+#include <iostream>
+
+struct LogProvider : public wis::LogLayer {
+    virtual void Log(wis::Severity sev, std::string message, wis::source_location sl = wis::source_location::current()) override
+    {
+        std::cout << wis::format("[{}]: {}\n", wis::severity_strings[+sev], message);
+    };
+};
+
+static void DebugCallback(wis::Severity severity, const char* message, void* user_data)
+{
+    std::cout << message << std::endl;
+    if (severity >= wis::Severity::Error) {
+        auto& error = *static_cast<bool*>(user_data);
+        error = true;
+    }
+}
+
+TEST_CASE("move_fence_dx12")
+{
+    wis::LibLogger::SetLogLayer(std::make_shared<LogProvider>());
+
+    bool error = false;
+
+    wis::DebugExtension ext;
+    std::array<wis::FactoryExtension*, 1> exts = { &ext };
+
+    auto [res, factory] = wis::CreateFactory(true, exts.data(), 1);
+    auto [res1, info] = ext.CreateDebugMessenger(&DebugCallback, &error);
+
+    wis::Device device;
+
+    for (size_t i = 0;; i++) {
+        auto [res, adapter] = factory.GetAdapter(i);
+        if (res.status == wis::Status::Ok) {
+            wis::AdapterDesc desc;
+            res = adapter.GetDesc(&desc);
+            std::cout << "Adapter: " << desc.description.data() << "\n";
+
+            auto [res, hdevice] = wis::CreateDevice(std::move(adapter));
+            if (res.status == wis::Status::Ok) {
+                device = std::move(hdevice);
+                break;
+            };
+
+        } else {
+            break;
+        }
+    }
+
+    auto [res2, queue] = device.CreateCommandQueue(wis::QueueType::Graphics);
+    auto [res3, fence] = device.CreateFence();
+    auto [res4, cmd_list] = device.CreateCommandList(wis::QueueType::Graphics);
+    auto [res5, allocator] = device.CreateAllocator();
+
+    REQUIRE(device);
+    REQUIRE(queue);
+    REQUIRE(fence);
+    REQUIRE(cmd_list);
+
+    auto fence2 = std::move(fence);
+    REQUIRE(fence2);
+
+    auto& internal = fence.GetInternal();
+    REQUIRE(internal.fence.get() == nullptr);
+    REQUIRE(internal.fence_event.get() == 0);
+}

--- a/wisdom/cmake/documentation.cmake
+++ b/wisdom/cmake/documentation.cmake
@@ -33,6 +33,7 @@ if(WISDOM_BUILD_DOCS)
             ${CMAKE_CURRENT_SOURCE_DIR}/docs/Doxyfile.in
             ${CMAKE_CURRENT_SOURCE_DIR}/docs/DoxygenLayout.xml
             ${CMAKE_CURRENT_SOURCE_DIR}/docs/main_page.h
+            ${CMAKE_CURRENT_SOURCE_DIR}/docs/contributing.h
             ${CMAKE_CURRENT_SOURCE_DIR}/docs/getting_started.h
         )
 

--- a/wisdom/docs/contributing.h
+++ b/wisdom/docs/contributing.h
@@ -1,0 +1,275 @@
+﻿/**
+ * @page contributing_page Contributing
+ *
+ * This page provides a comprehensive guide on how to contribute to the Wisdom project.
+ *
+ * @section overview_sec Overview
+ *
+ * We welcome contributions to the Wisdom project! Whether you're fixing bugs, adding features, improving documentation, or helping with testing, your contributions are valuable to the community.
+ *
+ * Before contributing, please familiarize yourself with our codebase structure and coding standards outlined below.
+ *
+ * @section getting_started_contributing Getting Started
+ *
+ * 1. **Fork the repository** on GitHub: https://github.com/Agrael1/Wisdom
+ * 2. **Clone your fork** locally: `git clone https://github.com/your-username/Wisdom.git`
+ * 3. **Create a feature branch**: `git checkout -b feature/your-feature-name`
+ * 4. **Set up the build environment** following the @ref getting_started_page "Getting Started" guide
+ * 5. **Make your changes** following our coding standards
+ * 6. **Test your changes** thoroughly
+ * 7. **Submit a pull request**
+ *
+ * @section coding_standards_sec Coding Standards and Best Practices
+ *
+ * @subsection code_style Code Style
+ *
+ * The Wisdom project uses a **custom clang-format configuration** located in `.clang-format` at the root of the repository. All code should be formatted according to this style:
+ *
+ * - **Base Style**: WebKit
+ * - **Pointer Alignment**: `Type* pointer` (pointer binds to type)
+ * - **Brace Style**: Custom with specific wrapping rules
+ * - **Template Declarations**: Always break before template declarations
+ *
+ * **To format your code:**
+ * ```bash
+ * clang-format -i --style=file your-file.cpp
+ * ```
+ * Or use your IDE's built-in clang-format support.
+ *
+ * @note The generator automatically formats generated files using clang-format during the build process.
+ * The repo formatting is also enforced in CI using GitHub Actions, so you don't have to worry about it.
+ *
+ * @subsection naming_conventions Naming Conventions
+ *
+ * Names follow Windows API conventions where applicable:
+ * - **Implementation Classes**: PascalCase (e.g., `ImplDX12Device`, `CommandQueue`, `DescriptorStorage`)
+ * - **Functions**: PascalCase (e.g., `CreateFactory`, `GetAdapter`)
+ * - **Variables and constants**: snake_case (e.g., `command_list`, `descriptor_heap`)
+ * - **Defines**: SCREAMING_SNAKE_CASE (e.g., `WISDOM_VERSION`)
+ * - **Enums and enum values**: PascalCase (e.g., `Status`, `Ok`, `ErrorInvalidArgument`)
+ * - **Container Classes**: snake_case (e.g., `unique_event`). These are usually templated containers or wrappers around STL containers.
+ * - **Namespaces**: snake_case (e.g., `wis`)
+ * 
+ * @note I just prefer this style, it is not strictly enforced.
+ *
+ * @subsection api_design API Design Principles
+ *
+ * - **Result-based returns**: Most functions return `wis::Result` as 1st value, that allows RVO and easy error handling
+ * - **RAII compliance**: All resources manage their own lifetime, no raw pointers outside of implementation
+ * - **Move semantics**: Most classes are move-only to prevent resource duplication
+ * - **No virtual functions**: Direct API calls for maximum performance, unless designing extension classes for device or factory
+ * - **Platform abstraction**: Code should work on both DirectX 12 and Vulkan backends, unless explicitly stated otherwise
+ *
+ * @subsection language_standards Language Standards
+ *
+ * - **Primary**: C++20 (required)
+ * - **Supported**: C++23 features where available. If you want to use C++23 features, please ensure they are supported by all target compilers by using feature macros. Don't use `__cplusplus`! It is unreliable on MSVC.
+ * - **Legacy**: If you see any C++17 or older constructs, please consider updating them to modern C++20 equivalents.
+ * - **Modules**: Experimental C++20 modules support (opt-in via `WISDOM_EXPERIMENTAL_CPP_MODULES`). Modules are not required and the project fully supports traditional headers.
+ *
+ * @section build_requirements_sec Build Requirements
+ *
+ * @subsection cmake_requirements CMake Requirements
+ *
+ * - **Minimum CMake version**: 3.28
+ * - **Build system**: Ninja (recommended)
+ * - **Presets**: Use CMake presets for consistent builds
+ *
+ * @subsection compiler_requirements Compiler Requirements
+ *
+ * - **Windows**: MSVC 2022 or Clang 16+
+ * - **Linux**: GCC 13+ or Clang 16+
+ * - **C++20 standard library**: Required for `std::format` (or use `WISDOM_USE_FMT=ON`)
+ *
+ * @section testing_sec Testing
+ *
+ * @subsection test_framework Test Framework
+ *
+ * The project uses **Catch2 v3 Unit Test Framework** for testing. Tests are located in the `tests/` directory.
+ *
+ * @subsection running_tests Running Tests
+ *
+ * ```bash
+ * # Build with tests enabled (default when building as top-level project)
+ * cmake --preset x64-debug -DWISDOM_BUILD_TESTS=ON
+ * cmake --build --preset x64-debug
+ *
+ * # Run tests
+ * ctest --preset x64-debug
+ * ```
+ *
+ * @subsection writing_tests Writing Tests
+ *
+ * - Place test files in `tests/basic/` or appropriate subdirectory
+ * - Use Catch2 macros: `TEST_CASE`, `REQUIRE`, `CHECK`
+ * - Test both DirectX 12 and Vulkan backends when applicable
+ * - Include proper cleanup and resource management
+ *
+ * **Example test structure:**
+ * ```cpp
+ * #include <catch2/catch_test_macros.hpp>
+ * #include <wisdom/wisdom.hpp>
+ *
+ * TEST_CASE("your_test_name") {
+ *     // Setup
+ *     auto [result, factory] = wis::CreateFactory();
+ *     REQUIRE(result.status == wis::Status::Ok);
+ *
+ *     // Test logic
+ *     // ...
+ *
+ *     // Assertions
+ *     REQUIRE(condition);
+ * }
+ * ```
+ *
+ * @section documentation_sec Documentation
+ *
+ * @subsection doxygen_docs Doxygen Documentation
+ *
+ * - All public APIs must be documented with Doxygen comments
+ * - Follow RFC 2119 guidelines for requirement levels (MUST, SHOULD, MAY)
+ * - Use `@param`, `@return`, `@note`, `@code` appropriately
+ * - Documentation is automatically generated and deployed to GitHub Pages
+ *
+ * @subsection doc_generation Documentation Generation
+ *
+ * ```bash
+ * # Enable documentation build
+ * cmake --preset x64-release -DWISDOM_BUILD_DOCS=ON
+ * cmake --build --preset x64-release --target docs
+ * ```
+ *
+ * @section extension_development_sec Extension Development
+ *
+ * @subsection creating_extensions Creating Extensions
+ *
+ * - Place extensions in `wisdom/extensions/your_extension/`
+ * - Follow existing extension patterns (see `wisdom/extensions/debug/`, `wisdom/extensions/raytracing/`)
+ * - Provide both header-only and library targets
+ * - Include CMake integration
+ *
+ * @subsection extension_structure Extension Structure
+ *
+ * ```
+ * wisdom/extensions/your_extension/
+ * ├── CMakeLists.txt
+ * ├── wisdom/
+ * │   ├── your_extension.hpp
+ * │   ├── your_extension.include.h
+ * │   ├── dx12_your_extension.hpp
+ * │   ├── vk_your_extension.hpp
+ * │   └── impl/
+ * │       ├── dx12_your_extension.cpp
+ * │       └── vk_your_extension.cpp
+ * ```
+ *
+ * @section submission_guidelines_sec Submission Guidelines
+ *
+ * @subsection pull_requests Pull Requests
+ *
+ * 1. **Create descriptive commits**: Use clear, concise commit messages
+ * 2. **Target the right branch**: Submit PRs against the `master` branch
+ * 3. **Include tests**: New features should include appropriate tests
+ * 4. **Update documentation**: Update relevant documentation pages
+ * 5. **Check CI**: Ensure all GitHub Actions workflows pass
+ *
+ * @subsection pr_checklist Pull Request Checklist
+ *
+ * - [ ] Code follows the project's coding standards
+ * - [ ] Code is formatted with clang-format (forced in CI)
+ * - [ ] All tests pass locally
+ * - [ ] New tests added for new functionality
+ * - [ ] Documentation updated (if applicable)
+ * - [ ] No breaking changes (or clearly documented)
+ * - [ ] Vulkan and DirectX 12 backends both work (if applicable)
+ *
+ * @subsection commit_messages Commit Message Format
+ *
+ * Use descriptive commit messages that explain what and why:
+ *
+ * ```
+ * feat: add descriptor buffer extension support
+ *
+ * - Implement descriptor buffer for both DX12 and Vulkan
+ * - Add comprehensive tests for descriptor operations
+ * - Update documentation with usage examples
+ *
+ * Fixes #123
+ * ```
+ *
+ * @section ci_cd_sec Continuous Integration
+ *
+ * @subsection github_actions GitHub Actions
+ *
+ * The project uses GitHub Actions for CI/CD with the following workflows:
+ *
+ * - **Linux build**: Ubuntu with Vulkan backend
+ * - **Windows DirectX 12**: MSVC with DirectX 12 backend
+ * - **Windows Vulkan**: MSVC with Vulkan backend
+ * - **Windows Clang**: Clang with Vulkan and C++20 modules
+ * - **Documentation**: Auto-generated and deployed to GitHub Pages
+ * - **Release**: Automated NuGet and GitHub releases
+ *
+ * @subsection build_matrix Build Matrix
+ *
+ * All PRs are automatically tested against:
+ * - **Platforms**: Windows, Linux
+ * - **Compilers**: MSVC, Clang, GCC
+ * - **Graphics APIs**: DirectX 12, Vulkan
+ * - **Build types**: Debug, Release
+ *
+ * @section contribution_types_sec Types of Contributions
+ *
+ * @subsection bug_fixes Bug Fixes
+ *
+ * - Report bugs using GitHub Issues
+ * - Include minimal reproduction case
+ * - Specify platform, compiler, and graphics API
+ * - Test fixes on both graphics backends when possible
+ *
+ * @subsection feature_additions Feature Additions
+ *
+ * - Discuss major features in GitHub Issues first
+ * - Ensure cross-platform compatibility
+ * - Follow existing API patterns
+ * - Include comprehensive tests and documentation
+ *
+ * @subsection documentation_improvements Documentation Improvements
+ *
+ * - Fix typos, clarify explanations
+ * - Add usage examples
+ * - Improve API documentation
+ * - Update getting started guides
+ *
+ * @subsection platform_support Platform Support
+ *
+ * - Add support for new platforms
+ * - Improve existing platform integrations
+ * - Update CMake configuration
+ * - Ensure proper CI coverage
+ *
+ * @section cmake_flags_sec Important CMake Flags for Development
+ *
+ * - `WISDOM_BUILD_TESTS=ON`: Enable test compilation
+ * - `WISDOM_BUILD_EXAMPLES=ON`: Enable example compilation
+ * - `WISDOM_BUILD_DOCS=ON`: Enable documentation generation
+ * - `WISDOM_FORCE_VULKAN=ON`: Force Vulkan backend on Windows
+ * - `WISDOM_DEBUG_LAYER=ON`: Enable debug validation layers
+ * - `WISDOM_EXPERIMENTAL_CPP_MODULES=ON`: Enable C++20 modules
+ * - `WISDOM_USE_FMT=ON`: Use fmtlib instead of std::format
+ *
+ * @section community_sec Community and Communication
+ *
+ * - **Repository**: https://github.com/Agrael1/Wisdom
+ * - **Issues**: Use GitHub Issues for bug reports and feature requests
+ * - **Discussions**: Use GitHub Discussions for questions and general discussion
+ * - **Contact**: agrael@live.ru (for code of conduct violations)
+ *
+ * @section license_sec License
+ *
+ * By contributing to Wisdom, you agree that your contributions will be licensed under the same license as the project.
+ * Please see the LICENSE.txt file in the repository root for details.
+ *
+ * @note Thank you for your interest in contributing to Wisdom! Your contributions help make this library better for everyone.
+ */

--- a/wisdom/docs/main_page.h
+++ b/wisdom/docs/main_page.h
@@ -10,12 +10,24 @@
  *
  * @note DOCUMENTATION IS IN PROGRESS. Would appreciate any feedback or contributions to improve it.
  *
+ * @section rules_sec Coding Standards and Documentation
+ * Wisdom follows no particular coding standard, when it comes to implementation part. All the public API is generated with custom generator 
+ * and follows a consistent style. The code is documented using Doxygen, and we strive to keep the documentation up-to-date with the codebase.
+ * 
+ * @note Please refer to the @ref contributing_page "Contributing" page for guidelines on contributing to the project.
+ * 
+ * Documentation from 25.8.2025 will adhere to the RFC 2119 guidelines for requirement levels.
+ * Latest statement can be found here: https://www.rfc-editor.org/rfc/rfc2119.html
+ * 
  * @section navigation_sec Quick Navigation
  *
  * - @ref getting_started_page "Getting Started" - Learn how to build the library and integrate it into your project
  * - @ref setup_page "Consumption" - Installation and configuration instructions
  * - @ref library_structure "Library Structure" - Overview of the library structure and components
  * - @ref examples_page "Initialization" - Basic examples of how to use the Wisdom library
+ * 
+ * 
+ * - @ref contributing_page "Contributing" - Contribution guidelines and how to get involved
  *
  * @section features_sec Key Features
  *

--- a/wisdom/extensions/debug_info/wisdom/wisdom_debug.hpp
+++ b/wisdom/extensions/debug_info/wisdom/wisdom_debug.hpp
@@ -52,6 +52,10 @@ class DX12DebugExtension : public wis::ImplDX12DebugExtension
 {
 public:
     using wis::ImplDX12DebugExtension::ImplDX12DebugExtension;
+    DX12DebugExtension(const DX12DebugExtension&) = delete;
+    DX12DebugExtension(DX12DebugExtension&&) noexcept = default;
+    DX12DebugExtension& operator=(const DX12DebugExtension&) = delete;
+    DX12DebugExtension& operator=(DX12DebugExtension&&) noexcept = default;
 
 public:
     /**
@@ -142,6 +146,10 @@ class VKDebugExtension : public wis::ImplVKDebugExtension
 {
 public:
     using wis::ImplVKDebugExtension::ImplVKDebugExtension;
+    VKDebugExtension(const VKDebugExtension&) = delete;
+    VKDebugExtension(VKDebugExtension&&) noexcept = default;
+    VKDebugExtension& operator=(const VKDebugExtension&) = delete;
+    VKDebugExtension& operator=(VKDebugExtension&&) noexcept = default;
 
 public:
     /**

--- a/wisdom/extensions/descriptor_buffer/wisdom/dx12_descriptor_buffer.hpp
+++ b/wisdom/extensions/descriptor_buffer/wisdom/dx12_descriptor_buffer.hpp
@@ -64,7 +64,7 @@ public:
     void WriteTexture(uint64_t aligned_table_offset, uint32_t index, wis::DX12ShaderResourceView resource) noexcept
     {
         auto handle = heap->GetCPUDescriptorHandleForHeapStart();
-        handle.ptr += index * heap_increment;
+        handle.ptr += aligned_table_offset + index * heap_increment;
         auto& sampler_handle = std::get<0>(resource);
         device->CopyDescriptorsSimple(1, handle, sampler_handle, D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV);
     }
@@ -81,7 +81,7 @@ public:
     void WriteRWTexture(uint64_t aligned_table_offset, uint32_t index, wis::DX12UnorderedAccessTextureView uav) noexcept
     {
         auto handle = heap->GetCPUDescriptorHandleForHeapStart();
-        handle.ptr += index * heap_increment;
+        handle.ptr += aligned_table_offset + index * heap_increment;
 
         auto& uav_handle = std::get<0>(uav);
         device->CopyDescriptorsSimple(1, handle, uav_handle, D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV);
@@ -145,6 +145,10 @@ class DX12DescriptorBuffer : public wis::ImplDX12DescriptorBuffer
 {
 public:
     using wis::ImplDX12DescriptorBuffer::ImplDX12DescriptorBuffer;
+    DX12DescriptorBuffer(const DX12DescriptorBuffer&) = delete;
+    DX12DescriptorBuffer(DX12DescriptorBuffer&&) noexcept = default;
+    DX12DescriptorBuffer& operator=(const DX12DescriptorBuffer&) = delete;
+    DX12DescriptorBuffer& operator=(DX12DescriptorBuffer&&) noexcept = default;
 
 public:
     /**

--- a/wisdom/extensions/descriptor_buffer/wisdom/vk_descriptor_buffer.hpp
+++ b/wisdom/extensions/descriptor_buffer/wisdom/vk_descriptor_buffer.hpp
@@ -158,6 +158,10 @@ class VKDescriptorBuffer : public wis::ImplVKDescriptorBuffer
 {
 public:
     using wis::ImplVKDescriptorBuffer::ImplVKDescriptorBuffer;
+    VKDescriptorBuffer(const VKDescriptorBuffer&) = delete;
+    VKDescriptorBuffer(VKDescriptorBuffer&&) noexcept = default;
+    VKDescriptorBuffer& operator=(const VKDescriptorBuffer&) = delete;
+    VKDescriptorBuffer& operator=(VKDescriptorBuffer&&) noexcept = default;
 
 public:
     /**

--- a/wisdom/extensions/descriptor_buffer/wisdom/wisdom_descriptor_buffer.hpp
+++ b/wisdom/extensions/descriptor_buffer/wisdom/wisdom_descriptor_buffer.hpp
@@ -73,6 +73,10 @@ class DX12DescriptorBufferExtension : public wis::ImplDX12DescriptorBufferExtens
 {
 public:
     using wis::ImplDX12DescriptorBufferExtension::ImplDX12DescriptorBufferExtension;
+    DX12DescriptorBufferExtension(const DX12DescriptorBufferExtension&) = delete;
+    DX12DescriptorBufferExtension(DX12DescriptorBufferExtension&&) noexcept = default;
+    DX12DescriptorBufferExtension& operator=(const DX12DescriptorBufferExtension&) = delete;
+    DX12DescriptorBufferExtension& operator=(DX12DescriptorBufferExtension&&) noexcept = default;
 
 public:
     /**
@@ -272,6 +276,10 @@ class VKDescriptorBufferExtension : public wis::ImplVKDescriptorBufferExtension
 {
 public:
     using wis::ImplVKDescriptorBufferExtension::ImplVKDescriptorBufferExtension;
+    VKDescriptorBufferExtension(const VKDescriptorBufferExtension&) = delete;
+    VKDescriptorBufferExtension(VKDescriptorBufferExtension&&) noexcept = default;
+    VKDescriptorBufferExtension& operator=(const VKDescriptorBufferExtension&) = delete;
+    VKDescriptorBufferExtension& operator=(VKDescriptorBufferExtension&&) noexcept = default;
 
 public:
     /**

--- a/wisdom/extensions/extended_allocation/wisdom/wisdom_extended_allocation.hpp
+++ b/wisdom/extensions/extended_allocation/wisdom/wisdom_extended_allocation.hpp
@@ -61,6 +61,10 @@ class DX12ExtendedAllocation : public wis::ImplDX12ExtendedAllocation
 {
 public:
     using wis::ImplDX12ExtendedAllocation::ImplDX12ExtendedAllocation;
+    DX12ExtendedAllocation(const DX12ExtendedAllocation&) = delete;
+    DX12ExtendedAllocation(DX12ExtendedAllocation&&) noexcept = default;
+    DX12ExtendedAllocation& operator=(const DX12ExtendedAllocation&) = delete;
+    DX12ExtendedAllocation& operator=(DX12ExtendedAllocation&&) noexcept = default;
 
 public:
     /**
@@ -184,6 +188,10 @@ class VKExtendedAllocation : public wis::ImplVKExtendedAllocation
 {
 public:
     using wis::ImplVKExtendedAllocation::ImplVKExtendedAllocation;
+    VKExtendedAllocation(const VKExtendedAllocation&) = delete;
+    VKExtendedAllocation(VKExtendedAllocation&&) noexcept = default;
+    VKExtendedAllocation& operator=(const VKExtendedAllocation&) = delete;
+    VKExtendedAllocation& operator=(VKExtendedAllocation&&) noexcept = default;
 
 public:
     /**

--- a/wisdom/include/wisdom/dx12/dx12_allocator.h
+++ b/wisdom/include/wisdom/dx12/dx12_allocator.h
@@ -95,6 +95,10 @@ class DX12ResourceAllocator : public wis::ImplDX12ResourceAllocator
 {
 public:
     using wis::ImplDX12ResourceAllocator::ImplDX12ResourceAllocator;
+    DX12ResourceAllocator(const DX12ResourceAllocator&) = delete;
+    DX12ResourceAllocator(DX12ResourceAllocator&&) noexcept = default;
+    DX12ResourceAllocator& operator=(const DX12ResourceAllocator&) = delete;
+    DX12ResourceAllocator& operator=(DX12ResourceAllocator&&) noexcept = default;
 
 public:
     /**

--- a/wisdom/include/wisdom/dx12/dx12_command_list.h
+++ b/wisdom/include/wisdom/dx12/dx12_command_list.h
@@ -120,6 +120,10 @@ class DX12CommandList : public wis::ImplDX12CommandList
 {
 public:
     using wis::ImplDX12CommandList::ImplDX12CommandList;
+    DX12CommandList(const DX12CommandList&) = delete;
+    DX12CommandList(DX12CommandList&&) noexcept = default;
+    DX12CommandList& operator=(const DX12CommandList&) = delete;
+    DX12CommandList& operator=(DX12CommandList&&) noexcept = default;
 
 public:
     /**

--- a/wisdom/include/wisdom/dx12/dx12_command_queue.h
+++ b/wisdom/include/wisdom/dx12/dx12_command_queue.h
@@ -60,6 +60,10 @@ class DX12CommandQueue : public wis::ImplDX12CommandQueue
 {
 public:
     using wis::ImplDX12CommandQueue::ImplDX12CommandQueue;
+    DX12CommandQueue(const DX12CommandQueue&) = delete;
+    DX12CommandQueue(DX12CommandQueue&&) noexcept = default;
+    DX12CommandQueue& operator=(const DX12CommandQueue&) = delete;
+    DX12CommandQueue& operator=(DX12CommandQueue&&) noexcept = default;
 
 public:
     /**

--- a/wisdom/include/wisdom/dx12/dx12_descriptor_storage.h
+++ b/wisdom/include/wisdom/dx12/dx12_descriptor_storage.h
@@ -144,6 +144,10 @@ class DX12DescriptorStorage : public wis::ImplDX12DescriptorStorage
 {
 public:
     using wis::ImplDX12DescriptorStorage::ImplDX12DescriptorStorage;
+    DX12DescriptorStorage(const DX12DescriptorStorage&) = delete;
+    DX12DescriptorStorage(DX12DescriptorStorage&&) noexcept = default;
+    DX12DescriptorStorage& operator=(const DX12DescriptorStorage&) = delete;
+    DX12DescriptorStorage& operator=(DX12DescriptorStorage&&) noexcept = default;
 
 public:
     /**

--- a/wisdom/include/wisdom/dx12/dx12_device.h
+++ b/wisdom/include/wisdom/dx12/dx12_device.h
@@ -114,6 +114,10 @@ class DX12Device : public wis::ImplDX12Device
 {
 public:
     using wis::ImplDX12Device::ImplDX12Device;
+    DX12Device(const DX12Device&) = delete;
+    DX12Device(DX12Device&&) noexcept = default;
+    DX12Device& operator=(const DX12Device&) = delete;
+    DX12Device& operator=(DX12Device&&) noexcept = default;
 
 public:
     /**

--- a/wisdom/include/wisdom/dx12/dx12_factory.h
+++ b/wisdom/include/wisdom/dx12/dx12_factory.h
@@ -53,6 +53,10 @@ class DX12Factory : public wis::ImplDX12Factory
 {
 public:
     using wis::ImplDX12Factory::ImplDX12Factory;
+    DX12Factory(const DX12Factory&) = delete;
+    DX12Factory(DX12Factory&&) noexcept = default;
+    DX12Factory& operator=(const DX12Factory&) = delete;
+    DX12Factory& operator=(DX12Factory&&) noexcept = default;
 
 public:
     /**

--- a/wisdom/include/wisdom/dx12/dx12_fence.h
+++ b/wisdom/include/wisdom/dx12/dx12_fence.h
@@ -62,6 +62,10 @@ class DX12Fence : public wis::ImplDX12Fence
 {
 public:
     using wis::ImplDX12Fence::ImplDX12Fence;
+    DX12Fence(const DX12Fence&) = delete;
+    DX12Fence(DX12Fence&&) noexcept = default;
+    DX12Fence& operator=(const DX12Fence&) = delete;
+    DX12Fence& operator=(DX12Fence&&) noexcept = default;
 
 public:
     /**

--- a/wisdom/include/wisdom/dx12/dx12_memory.h
+++ b/wisdom/include/wisdom/dx12/dx12_memory.h
@@ -60,6 +60,10 @@ class DX12Memory : public wis::ImplDX12Memory
 {
 public:
     using wis::ImplDX12Memory::ImplDX12Memory;
+    DX12Memory(const DX12Memory&) = delete;
+    DX12Memory(DX12Memory&&) noexcept = default;
+    DX12Memory& operator=(const DX12Memory&) = delete;
+    DX12Memory& operator=(DX12Memory&&) noexcept = default;
 
 public:
     /**

--- a/wisdom/include/wisdom/dx12/dx12_resource.h
+++ b/wisdom/include/wisdom/dx12/dx12_resource.h
@@ -65,6 +65,11 @@ template<>
 struct Internal<DX12RenderTarget> {
     wis::com_ptr<ID3D12DescriptorHeap> heap;
     D3D12_CPU_DESCRIPTOR_HANDLE handle{};
+
+    // Move only
+    Internal() = default;
+    Internal(Internal&&) noexcept = default;
+    Internal& operator=(Internal&& o) noexcept = default;
 };
 
 WISDOM_EXPORT
@@ -90,6 +95,11 @@ WISDOM_EXPORT
 template<>
 struct Internal<DX12Sampler> {
     wis::com_ptr<ID3D12DescriptorHeap> heap;
+
+    // Move only
+    Internal() = default;
+    Internal(Internal&&) noexcept = default;
+    Internal& operator=(Internal&& o) noexcept = default;
 };
 
 WISDOM_EXPORT
@@ -115,6 +125,11 @@ WISDOM_EXPORT
 template<>
 struct Internal<DX12ShaderResource> {
     wis::com_ptr<ID3D12DescriptorHeap> heap;
+
+    // Move only
+    Internal() = default;
+    Internal(Internal&&) noexcept = default;
+    Internal& operator=(Internal&& o) noexcept = default;
 };
 
 WISDOM_EXPORT
@@ -144,6 +159,10 @@ class DX12Buffer : public wis::ImplDX12Buffer
 {
 public:
     using wis::ImplDX12Buffer::ImplDX12Buffer;
+    DX12Buffer(const DX12Buffer&) = delete;
+    DX12Buffer(DX12Buffer&&) noexcept = default;
+    DX12Buffer& operator=(const DX12Buffer&) = delete;
+    DX12Buffer& operator=(DX12Buffer&&) noexcept = default;
 
 public:
     /**

--- a/wisdom/include/wisdom/dx12/dx12_root_signature.h
+++ b/wisdom/include/wisdom/dx12/dx12_root_signature.h
@@ -16,6 +16,14 @@ struct Internal<DX12RootSignature> {
     std::array<int8_t, size_t(wis::ShaderStages::Count)> stage_map;
     uint32_t push_constant_count = 0;
     uint32_t push_descriptor_count = 0;
+
+    // Allow move only
+    Internal() noexcept
+    {
+        stage_map.fill(-1);
+    }
+    Internal(Internal&&) noexcept = default;
+    Internal& operator=(Internal&& o) noexcept = default;
 };
 
 WISDOM_EXPORT

--- a/wisdom/include/wisdom/dx12/dx12_swapchain.h
+++ b/wisdom/include/wisdom/dx12/dx12_swapchain.h
@@ -116,6 +116,10 @@ class DX12SwapChain : public wis::ImplDX12SwapChain
 {
 public:
     using wis::ImplDX12SwapChain::ImplDX12SwapChain;
+    DX12SwapChain(const DX12SwapChain&) = delete;
+    DX12SwapChain(DX12SwapChain&&) noexcept = default;
+    DX12SwapChain& operator=(const DX12SwapChain&) = delete;
+    DX12SwapChain& operator=(DX12SwapChain&&) noexcept = default;
 
 public:
     /**

--- a/wisdom/include/wisdom/dx12/dx12_unique_event.h
+++ b/wisdom/include/wisdom/dx12/dx12_unique_event.h
@@ -15,6 +15,10 @@ struct unique_event {
         : hevent(std::exchange(o.hevent, nullptr)) { }
     unique_event& operator=(unique_event&& o) noexcept
     {
+        if (this == &o) {
+            return *this;
+        }
+
         std::swap(hevent, o.hevent);
         return *this;
     }

--- a/wisdom/include/wisdom/dx12/dx12_unique_event.h
+++ b/wisdom/include/wisdom/dx12/dx12_unique_event.h
@@ -15,10 +15,6 @@ struct unique_event {
         : hevent(std::exchange(o.hevent, nullptr)) { }
     unique_event& operator=(unique_event&& o) noexcept
     {
-        if (this == &o) {
-            return *this;
-        }
-
         std::swap(hevent, o.hevent);
         return *this;
     }

--- a/wisdom/include/wisdom/dx12/dx12_unique_event.h
+++ b/wisdom/include/wisdom/dx12/dx12_unique_event.h
@@ -15,6 +15,7 @@ struct unique_event {
         : hevent(std::exchange(o.hevent, nullptr)) { }
     unique_event& operator=(unique_event&& o) noexcept
     {
+        clear();
         std::swap(hevent, o.hevent);
         return *this;
     }
@@ -42,6 +43,13 @@ struct unique_event {
             return wis::Status::Timeout;
         }
         return wis::Status::Error;
+    }
+    void clear() noexcept
+    {
+        if (hevent) {
+            CloseHandle(hevent);
+            hevent = nullptr;
+        }
     }
 
 public:

--- a/wisdom/include/wisdom/generated/api/api.hpp
+++ b/wisdom/include/wisdom/generated/api/api.hpp
@@ -9,7 +9,7 @@
 #define WISDOM_EXPORT export
 #endif
 
-/** Wisdom API Version 0.6.11
+/** Wisdom API Version 0.6.12
 
 Copyright (c) 2024 Ilya Doroshenko. All rights reserved.
 License: MIT
@@ -1525,7 +1525,7 @@ enum class ASInstanceFlags {
 /**
  * @struct wis::Result
  * @brief Main source of communication of operation success.
- * To check for success compare wis::Result::status with wis::Status::Ok.
+ * To check for success wis::Result::status *must* be compared with wis::Status::Ok.
  * If there is any error there is  string which is compile-time.
  * It communicates the source of problems even in Release mode.
  * The string contains function name and error message.

--- a/wisdom/include/wisdom/generated/api/wisdom.api.ixx
+++ b/wisdom/include/wisdom/generated/api/wisdom.api.ixx
@@ -1,4 +1,4 @@
-/** Wisdom API Version 0.6.11
+/** Wisdom API Version 0.6.12
 
 Copyright (c) 2024 Ilya Doroshenko. All rights reserved.
 License: MIT

--- a/wisdom/include/wisdom/generated/dx12/wisdom.dx12.ixx
+++ b/wisdom/include/wisdom/generated/dx12/wisdom.dx12.ixx
@@ -1,4 +1,4 @@
-/** Wisdom API Version 0.6.11
+/** Wisdom API Version 0.6.12
 
 Copyright (c) 2024 Ilya Doroshenko. All rights reserved.
 License: MIT

--- a/wisdom/include/wisdom/generated/vulkan/wisdom.vk.ixx
+++ b/wisdom/include/wisdom/generated/vulkan/wisdom.vk.ixx
@@ -1,4 +1,4 @@
-/** Wisdom API Version 0.6.11
+/** Wisdom API Version 0.6.12
 
 Copyright (c) 2024 Ilya Doroshenko. All rights reserved.
 License: MIT

--- a/wisdom/include/wisdom/vulkan/vk_allocator.h
+++ b/wisdom/include/wisdom/vulkan/vk_allocator.h
@@ -107,6 +107,10 @@ class VKResourceAllocator : public wis::ImplVKResourceAllocator
 {
 public:
     using wis::ImplVKResourceAllocator::ImplVKResourceAllocator;
+    VKResourceAllocator(const VKResourceAllocator&) = delete;
+    VKResourceAllocator(VKResourceAllocator&&) noexcept = default;
+    VKResourceAllocator& operator=(const VKResourceAllocator&) = delete;
+    VKResourceAllocator& operator=(VKResourceAllocator&&) noexcept = default;
 
 public:
     /**

--- a/wisdom/include/wisdom/vulkan/vk_command_list.h
+++ b/wisdom/include/wisdom/vulkan/vk_command_list.h
@@ -168,6 +168,10 @@ class VKCommandList : public wis::ImplVKCommandList
 {
 public:
     using wis::ImplVKCommandList::ImplVKCommandList;
+    VKCommandList(const VKCommandList&) = delete;
+    VKCommandList(VKCommandList&&) noexcept = default;
+    VKCommandList& operator=(const VKCommandList&) = delete;
+    VKCommandList& operator=(VKCommandList&&) noexcept = default;
 
 public:
     /**

--- a/wisdom/include/wisdom/vulkan/vk_command_queue.h
+++ b/wisdom/include/wisdom/vulkan/vk_command_queue.h
@@ -59,6 +59,10 @@ class VKCommandQueue : public wis::ImplVKCommandQueue
 {
 public:
     using wis::ImplVKCommandQueue::ImplVKCommandQueue;
+    VKCommandQueue(const VKCommandQueue&) = delete;
+    VKCommandQueue(VKCommandQueue&&) noexcept = default;
+    VKCommandQueue& operator=(const VKCommandQueue&) = delete;
+    VKCommandQueue& operator=(VKCommandQueue&&) noexcept = default;
 
 public:
     /**

--- a/wisdom/include/wisdom/vulkan/vk_descriptor_storage.h
+++ b/wisdom/include/wisdom/vulkan/vk_descriptor_storage.h
@@ -205,6 +205,10 @@ class VKDescriptorStorage : public wis::ImplVKDescriptorStorage
 {
 public:
     using wis::ImplVKDescriptorStorage::ImplVKDescriptorStorage;
+    VKDescriptorStorage(const VKDescriptorStorage&) = delete;
+    VKDescriptorStorage(VKDescriptorStorage&&) noexcept = default;
+    VKDescriptorStorage& operator=(const VKDescriptorStorage&) = delete;
+    VKDescriptorStorage& operator=(VKDescriptorStorage&&) noexcept = default;
 
 public:
     /**

--- a/wisdom/include/wisdom/vulkan/vk_device.h
+++ b/wisdom/include/wisdom/vulkan/vk_device.h
@@ -161,6 +161,10 @@ class VKDevice : public wis::ImplVKDevice
 {
 public:
     using wis::ImplVKDevice::ImplVKDevice;
+    VKDevice(const VKDevice&) = delete;
+    VKDevice(VKDevice&&) noexcept = default;
+    VKDevice& operator=(const VKDevice&) = delete;
+    VKDevice& operator=(VKDevice&&) noexcept = default;
 
 public:
     /**

--- a/wisdom/include/wisdom/vulkan/vk_factory.h
+++ b/wisdom/include/wisdom/vulkan/vk_factory.h
@@ -128,6 +128,10 @@ class VKFactory : public wis::ImplVKFactory
 {
 public:
     using wis::ImplVKFactory::ImplVKFactory;
+    VKFactory(const VKFactory&) = delete;
+    VKFactory(VKFactory&&) noexcept = default;
+    VKFactory& operator=(const VKFactory&) = delete;
+    VKFactory& operator=(VKFactory&&) noexcept = default;
 
 public:
     /**

--- a/wisdom/include/wisdom/vulkan/vk_fence.h
+++ b/wisdom/include/wisdom/vulkan/vk_fence.h
@@ -4,7 +4,6 @@
 #include <wisdom/vulkan/vk_views.h>
 #include <wisdom/vulkan/vk_checks.h>
 #include <wisdom/global/internal.h>
-#include <wisvk/vk_loader.hpp>
 #include <limits>
 #endif // !WISDOM_MODULE_DECL
 

--- a/wisdom/include/wisdom/vulkan/vk_fence.h
+++ b/wisdom/include/wisdom/vulkan/vk_fence.h
@@ -57,6 +57,10 @@ class VKFence : public wis::ImplVKFence
 {
 public:
     using wis::ImplVKFence::ImplVKFence;
+    VKFence(const VKFence&) = delete;
+    VKFence(VKFence&&) noexcept = default;
+    VKFence& operator=(const VKFence&) = delete;
+    VKFence& operator=(VKFence&&) noexcept = default;
 
 public:
     /**

--- a/wisdom/include/wisdom/vulkan/vk_memory.h
+++ b/wisdom/include/wisdom/vulkan/vk_memory.h
@@ -101,6 +101,10 @@ class VKMemory : public wis::ImplVKMemory
 {
 public:
     using wis::ImplVKMemory::ImplVKMemory;
+    VKMemory(const VKMemory&) = delete;
+    VKMemory(VKMemory&&) noexcept = default;
+    VKMemory& operator=(const VKMemory&) = delete;
+    VKMemory& operator=(VKMemory&&) noexcept = default;
 
 public:
     /**

--- a/wisdom/include/wisdom/vulkan/vk_resource.h
+++ b/wisdom/include/wisdom/vulkan/vk_resource.h
@@ -218,6 +218,10 @@ class VKBuffer : public wis::ImplVKBuffer
 {
 public:
     using wis::ImplVKBuffer::ImplVKBuffer;
+    VKBuffer(const VKBuffer&) = delete;
+    VKBuffer(VKBuffer&&) noexcept = default;
+    VKBuffer& operator=(const VKBuffer&) = delete;
+    VKBuffer& operator=(VKBuffer&&) noexcept = default;
 
 public:
     /**

--- a/wisdom/include/wisdom/vulkan/vk_swapchain.h
+++ b/wisdom/include/wisdom/vulkan/vk_swapchain.h
@@ -120,6 +120,10 @@ class VKSwapChain : public wis::ImplVKSwapChain
 {
 public:
     using wis::ImplVKSwapChain::ImplVKSwapChain;
+    VKSwapChain(const VKSwapChain&) = delete;
+    VKSwapChain(VKSwapChain&&) noexcept = default;
+    VKSwapChain& operator=(const VKSwapChain&) = delete;
+    VKSwapChain& operator=(VKSwapChain&&) noexcept = default;
 
 public:
     /**

--- a/wisdom/include/wisdom/vulkan/vk_views.h
+++ b/wisdom/include/wisdom/vulkan/vk_views.h
@@ -4,7 +4,6 @@
 #include <tuple>
 #include <span>
 #include <wisdom/vulkan/vk_handles.h>
-#include <wisvk/vk_loader.hpp>
 #include <wisdom/generated/api/api.hpp>
 #endif // !WISDOM_MODULE_DECL
 

--- a/xml/structs.xml
+++ b/xml/structs.xml
@@ -66,7 +66,7 @@
 
     <!--Structs-->
     <type name="Result" category="struct" doc="Main source of communication of operation success.
-To check for success compare {::status} with {Status::Ok}.
+To check for success {::status} *must* be compared with {Status::Ok}.
 If there is any error there is {::error} string which is compile-time.
 It communicates the source of problems even in Release mode.
 The string contains function name and error message.">


### PR DESCRIPTION
This commit introduces move-only semantics across various classes, deleting copy constructors and assignment operators while defaulting move constructors and assignment operators. Key changes include:

- Updated `CreateExternalBuffer` method parameters in `work_node.h` and `transfer_node.h` to use reference types for improved performance.
- Added a new source file, `copy_tests.cpp`, to the `CMakeLists.txt` for testing copy semantics.
- Modified `generator.cpp` to conditionally generate copy and move constructors, prohibiting copying for all classes except `Adapter`.
- Enhanced several classes (e.g., `DX12DebugExtension`, `VKDebugExtension`, `DX12DescriptorBuffer`) to enforce move-only semantics.
- Introduced a new test file, `fence_move_dx12.cpp`, to validate the implementation of move semantics in DirectX 12.
- Fixed bug in DescriptorBuffer DX12 implementation, with WriteTexture not accounting for aligned table offset

These changes improve code safety and performance by minimizing the risk of accidental copies in resource management scenarios.